### PR TITLE
fix: Template base URL, Panics, and nil func returns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ vendor
 
 # Task local state
 .task
+
+# VSCode debugger launch configs
+launch.json

--- a/cmd/stencil/create_module.go
+++ b/cmd/stencil/create_module.go
@@ -81,11 +81,9 @@ func NewCreateModule() *cli.Command {
 			tm := &configuration.Manifest{
 				Name: path.Base(c.Args().Get(0)),
 				Modules: []*configuration.TemplateRepository{{
-					Name: "go.rgst.io/stencil-template-base",
+					Name: "github.com/getoutreach/stencil-template-base",
 				}, {
 					Name: "github.com/getoutreach/stencil-base",
-				}, {
-					Name: "go.rgst.io/stencil-circleci",
 				}},
 				Arguments: map[string]interface{}{
 					"reportingTeam": reportingTeam,

--- a/internal/codegen/stencil_test.go
+++ b/internal/codegen/stencil_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 	"testing"
 
@@ -91,9 +92,19 @@ func TestModuleHookRender(t *testing.T) {
 
 	tpls, err := st.Render(ctx, logrus.New())
 	assert.NilError(t, err, "expected Render() to not fail")
-	assert.Equal(t, len(tpls), 2, "expected Render() to return a single template")
-	assert.Equal(t, len(tpls[1].Files), 1, "expected Render() template to return a single file")
-	assert.Equal(t, strings.TrimSpace(tpls[1].Files[0].String()), "a", "expected Render() to return correct output")
+	assert.Equal(t, len(tpls), 2, "expected Render() to return two templates")
+	// template return order is randomized to prevent order dependencies
+	slices.SortFunc(tpls, func(a, b *Template) int {
+		if a.Module.Name < b.Module.Name {
+			return -1
+		}
+		if a.Module.Name > b.Module.Name {
+			return 1
+		}
+		return 0
+	})
+	assert.Equal(t, len(tpls[1].Files), 1, "expected Render() m2 template to return a single file")
+	assert.Equal(t, strings.TrimSpace(tpls[1].Files[0].String()), "a", "expected Render() m2 to return correct output")
 }
 
 func ExampleStencil_PostRun() {

--- a/internal/codegen/testdata/module-hook/m1.tpl
+++ b/internal/codegen/testdata/module-hook/m1.tpl
@@ -1,2 +1,2 @@
-{{ file.Skip "virtual file" }}
-{{ stencil.AddToModuleHook "testing2" "coolthing" (list "a") }}
+{{- file.Skip "virtual file" -}}
+{{- stencil.AddToModuleHook "testing2" "coolthing" (list "a") -}}

--- a/internal/codegen/tpl.go
+++ b/internal/codegen/tpl.go
@@ -23,7 +23,7 @@ func NewFuncMap(st *Stencil, t *Template, log logrus.FieldLogger) template.FuncM
 	if st != nil {
 		tplst = &TplStencil{st, t, log}
 	}
-	if t != nil {
+	if t != nil && len(t.Files) > 0 {
 		tplf = &TplFile{t.Files[0], t, log}
 	}
 

--- a/internal/codegen/tpl_file.go
+++ b/internal/codegen/tpl_file.go
@@ -51,7 +51,7 @@ func (f *TplFile) Block(name string) string {
 
 // SetPath changes the path of the current file being rendered
 //
-//	{{ file.SetPath "new/path/to/file.txt" }}
+//	{{- file.SetPath "new/path/to/file.txt" }}
 func (f *TplFile) SetPath(path string) (out string, err error) {
 	err = f.f.SetPath(path)
 	return "", err
@@ -69,7 +69,7 @@ func (f *TplFile) SetContents(contents string) error {
 
 // Skip skips the current file being rendered
 //
-//	{{ file.Skip "A reason to skip this file" }}
+//	{{- file.Skip "A reason to skip this file" }}
 func (f *TplFile) Skip(reason string) (output string, err error) {
 	f.f.Skipped = true
 	f.f.SkippedReason = reason

--- a/internal/codegen/tpl_file.go
+++ b/internal/codegen/tpl_file.go
@@ -51,13 +51,10 @@ func (f *TplFile) Block(name string) string {
 
 // SetPath changes the path of the current file being rendered
 //
-//	{{ $_ := file.SetPath "new/path/to/file.txt" }}
-//
-// Note: The $_ is required to ensure <nil> isn't outputted into
-// the template.
-func (f *TplFile) SetPath(path string) (out, err error) {
+//	{{ file.SetPath "new/path/to/file.txt" }}
+func (f *TplFile) SetPath(path string) (out string, err error) {
 	err = f.f.SetPath(path)
-	return err, err
+	return "", err
 }
 
 // SetContents sets the contents of file being rendered to the value
@@ -72,11 +69,11 @@ func (f *TplFile) SetContents(contents string) error {
 
 // Skip skips the current file being rendered
 //
-//	{{ $_ := file.Skip "A reason to skip this reason" }}
-func (f *TplFile) Skip(reason string) error {
+//	{{ file.Skip "A reason to skip this file" }}
+func (f *TplFile) Skip(reason string) (output string, err error) {
 	f.f.Skipped = true
 	f.f.SkippedReason = reason
-	return nil
+	return "", nil
 }
 
 // Delete deletes the current file being rendered
@@ -95,17 +92,16 @@ func (f *TplFile) Delete() error {
 // recommended that you do not do this as it limits your ability to change
 // the file in the future.
 //
-//	{{ $_ := file.Static }}
-func (f *TplFile) Static() (out, err error) {
+//	{{ file.Static }}
+func (f *TplFile) Static() (out string, err error) {
 	// if the file already exists, skip it
 	if _, err := os.Stat(f.f.path); err == nil {
 		f.log.WithField("template", f.t.Path).WithField("path", f.f.path).
 			Debug("Skipping static file because it already exists")
-		err := f.Skip("Static file, output already exists")
-		return err, err
+		return f.Skip("Static file, output already exists")
 	}
 
-	return nil, nil
+	return "", nil
 }
 
 // Path returns the current path of the file we're writing to

--- a/internal/codegen/tpl_stencil.go
+++ b/internal/codegen/tpl_stencil.go
@@ -77,10 +77,10 @@ func (s *TplStencil) GetModuleHook(name string) []any {
 //
 //	{{- /* This writes a global into the current context of the template module repository */}}
 //	{{ stencil.SetGlobal "IsGeorgeCool" true }}
-func (s *TplStencil) SetGlobal(name string, data interface{}) error {
+func (s *TplStencil) SetGlobal(name string, data interface{}) (output string, err error) {
 	// Only modify on first pass
 	if !s.s.isFirstPass {
-		return nil
+		return "", nil
 	}
 
 	k := s.s.sharedData.key(s.t.Module.Name, name)
@@ -92,7 +92,7 @@ func (s *TplStencil) SetGlobal(name string, data interface{}) error {
 		value:    data,
 	}
 
-	return nil
+	return "", nil
 }
 
 // GetGlobal retrieves a global variable set by SetGlobal. The data returned from this function
@@ -131,10 +131,10 @@ func (s *TplStencil) GetGlobal(name string) interface{} {
 //
 //	{{- /* This writes to a module hook */}}
 //	{{ stencil.AddToModuleHook "github.com/myorg/repo" "myModuleHook" (list "myData") }}
-func (s *TplStencil) AddToModuleHook(module, name string, data interface{}) (out, err error) {
+func (s *TplStencil) AddToModuleHook(module, name string, data interface{}) (out string, err error) {
 	// Only modify on first pass
 	if !s.s.isFirstPass {
-		return nil, nil
+		return "", nil
 	}
 
 	k := s.s.sharedData.key(module, name)
@@ -144,14 +144,14 @@ func (s *TplStencil) AddToModuleHook(module, name string, data interface{}) (out
 	v := reflect.ValueOf(data)
 	if !v.IsValid() {
 		err := fmt.Errorf("third parameter, data, must be set")
-		return err, err
+		return "", err
 	}
 
 	// we only allow slices or maps to allow multiple templates to
 	// write to the same block
 	if v.Kind() != reflect.Slice {
 		err := fmt.Errorf("unsupported module block data type %q, supported type is slice", v.Kind())
-		return err, err
+		return "", err
 	}
 
 	// convert the slice into a []any
@@ -167,7 +167,7 @@ func (s *TplStencil) AddToModuleHook(module, name string, data interface{}) (out
 		s.s.sharedData.moduleHooks[k] = &moduleHook{values: interfaceSlice}
 	}
 
-	return nil, nil
+	return "", nil
 }
 
 // ReadFile reads a file from the current directory and returns it's contents

--- a/internal/codegen/tpl_stencil.go
+++ b/internal/codegen/tpl_stencil.go
@@ -76,7 +76,7 @@ func (s *TplStencil) GetModuleHook(name string) []any {
 // occur if you're using the data it returns in the wrong way.
 //
 //	{{- /* This writes a global into the current context of the template module repository */}}
-//	{{ stencil.SetGlobal "IsGeorgeCool" true }}
+//	{{- stencil.SetGlobal "IsGeorgeCool" true -}}
 func (s *TplStencil) SetGlobal(name string, data interface{}) (output string, err error) {
 	// Only modify on first pass
 	if !s.s.isFirstPass {
@@ -130,7 +130,7 @@ func (s *TplStencil) GetGlobal(name string) interface{} {
 // times.
 //
 //	{{- /* This writes to a module hook */}}
-//	{{ stencil.AddToModuleHook "github.com/myorg/repo" "myModuleHook" (list "myData") }}
+//	{{- stencil.AddToModuleHook "github.com/myorg/repo" "myModuleHook" (list "myData") }}
 func (s *TplStencil) AddToModuleHook(module, name string, data interface{}) (out string, err error) {
 	// Only modify on first pass
 	if !s.s.isFirstPass {

--- a/internal/codegen/tpl_stencil_test.go
+++ b/internal/codegen/tpl_stencil_test.go
@@ -135,9 +135,8 @@ func TestTplStencil_GetModuleHook(t *testing.T) {
 
 			s.s.isFirstPass = true
 			for _, insert := range tt.inserts {
-				err1, err2 := s.AddToModuleHook(s.t.Module.Name, tt.args.name, insert)
-				if err1 != nil || err2 != nil {
-					t.Errorf("TplStencil.GetModuleHook() error = %v, %v", err1, err2)
+				if _, err := s.AddToModuleHook(s.t.Module.Name, tt.args.name, insert); err != nil {
+					t.Errorf("TplStencil.GetModuleHook() error = %v", err)
 					return
 				}
 			}


### PR DESCRIPTION
* Template base url was wrong in the module creation (left over from outreach days)
* If you return 0 files in rendering your template, then stencil panics -- fixed
* Updated the file template renders to not need the $_ = hack by just returning empty string as the output
* Added launch.json to gitignore for local debugging
