### PR TITLE
feat: support library templates

### DIFF
--- a/docs/reference/template-module.md
+++ b/docs/reference/template-module.md
@@ -35,7 +35,7 @@ Templates can also call `file.Create` to create a new file within a loop. For mo
 
 Library templates special templates that are meant to only contain
 functions callable by the current module. They cannot call `file`
-methods as they do not ever generate file.
+methods as they do not ever generate files.
 
 To create a library template, create a file with the `.library.tpl`
 extension.

--- a/docs/reference/template-module.md
+++ b/docs/reference/template-module.md
@@ -31,6 +31,15 @@ This can be changed with the [`file.SetPath`](/functions/file.SetPath) function 
 
 Templates can also call `file.Create` to create a new file within a loop. For more information see the [`file.Create` documentation](/functions/file.Create)
 
+#### Library Templates
+
+Library templates special templates that are meant to only contain
+functions callable by the current module. They cannot call `file`
+methods as they do not ever generate file.
+
+To create a library template, create a file with the `.library.tpl`
+extension.
+
 ### `manifest.yaml`
 
 The manifest.yaml file is arguably the most important file in a stencil module. This dictates the type of module, the arguments that the module accepts, and the dependencies that the module has.

--- a/internal/codegen/template.go
+++ b/internal/codegen/template.go
@@ -128,6 +128,7 @@ func (t *Template) Render(st *Stencil, vals *Values) error {
 	// we can return early here.
 	if t.Library {
 		t.Files = nil
+		return nil
 	}
 
 	// If we're writing only a single file, and the contents is empty

--- a/internal/codegen/tpl.go
+++ b/internal/codegen/tpl.go
@@ -6,6 +6,7 @@
 package codegen
 
 import (
+	"fmt"
 	"text/template"
 
 	"github.com/sirupsen/logrus"
@@ -30,7 +31,13 @@ func NewFuncMap(st *Stencil, t *Template, log logrus.FieldLogger) template.FuncM
 	// build the function map
 	funcs := Default
 	funcs["stencil"] = func() *TplStencil { return tplst }
-	funcs["file"] = func() *TplFile { return tplf }
+	funcs["file"] = func() *TplFile {
+		if tplf == nil {
+			panic(fmt.Errorf("attempted to use file in a template that doesn't support file rendering"))
+		}
+
+		return tplf
+	}
 	funcs["extensions"] = func() *extensions.ExtensionCaller { return st.extCaller }
 	return funcs
 }


### PR DESCRIPTION
This commit adds support for special "library" templates that can never
generate files. The intent for these is to provide helper
functions/sub-templates for other templates to call. A libary template
is any template file that has the `.library.tpl` extension.

Adds tests ensuring that this functionality works as expected as well as
updates the documentation to reflect the introduction of them.
