### PR TITLE
fix: allow upgrade cmd to install new modules

### DIFF
--- a/cmd/stencil/upgrade_test.go
+++ b/cmd/stencil/upgrade_test.go
@@ -71,3 +71,51 @@ func TestCanUpgradeModules(t *testing.T) {
 	assert.Equal(t, len(lf.Modules), 1, "expected exactly one module in lockfile")
 	assert.Check(t, lf.Modules[0].Version.Tag != "v0.3.1", "expected module to be upgraded")
 }
+
+// TestUpgradeIncludesNewModules tests that the upgrade command can install
+// new modules in a project.
+func TestUpgradeIncludesNewModules(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	cmd := NewUpgradeCommand(slogext.NewTestLogger(t))
+	assert.Assert(t, cmd != nil, "expected NewUpgradeCommand() to not return nil")
+
+	// Create a project with no modules. If it upgrades, we consider success.
+	mf := &configuration.Manifest{
+		Name: "testing",
+		Modules: []*configuration.TemplateRepository{{
+			Name: "github.com/rgst-io/stencil-golang",
+		}},
+	}
+
+	lock := &stencil.Lockfile{
+		Modules: []*stencil.LockfileModuleEntry{},
+	}
+
+	// Write the manifest and lockfile to disk
+	mfBytes, err := yaml.Marshal(mf)
+	assert.NilError(t, err, "failed to marshal manifest")
+
+	lockBytes, err := yaml.Marshal(lock)
+	assert.NilError(t, err, "failed to marshal lockfile")
+
+	err = os.WriteFile(filepath.Join(tmpDir, "stencil.yaml"), mfBytes, 0o644)
+	assert.NilError(t, err, "failed to write manifest")
+
+	os.WriteFile(filepath.Join(tmpDir, stencil.LockfileName), lockBytes, 0o644)
+	assert.NilError(t, err, "failed to write lockfile")
+
+	// Run the upgrade
+	err = testRunCommand(t, cmd, tmpDir)
+	if err != nil {
+		// Right now it errors due to no go.mod, so allow that error to
+		// occur. It doesn't indicate the upgrade failure.
+		assert.ErrorContains(t, err, "failed to run post run command")
+	}
+
+	// Read the lockfile back in and ensure that the module was added.
+	lf, err := stencil.LoadLockfile(tmpDir)
+	assert.NilError(t, err, "expected LoadLockfile() to not error")
+	assert.Equal(t, len(lf.Modules), 1, "expected exactly one module in lockfile")
+	assert.Check(t, lf.Modules[0].Version.Tag != "", "expected module to be latest version")
+}

--- a/internal/cmd/stencil/stencil.go
+++ b/internal/cmd/stencil/stencil.go
@@ -142,6 +142,9 @@ func (c *Command) Upgrade(ctx context.Context) error {
 
 			c.log.Infof(" -> %s (%s -> %s)", new.Name, printVersion(old), printVersion(new.Version))
 			hadChanges = true
+		} else {
+			c.log.Infof(" -> %s (%s)", new.Name, printVersion(new.Version))
+			hadChanges = true
 		}
 	}
 	if !hadChanges {


### PR DESCRIPTION
## What this PR does / why we need it
Changes in this PR allow `upgrade` command to add new modules if they do not exist in the lock file.

## Notes for your reviewers
I'm aware that his might be not the expected behaviour of the command. So, please feel free to close the PR if the reported issue (#103) is not a valid one