### PR TITLE
refactor(box)!: remove box configuration

### DIFF
--- a/internal/codegen/values.go
+++ b/internal/codegen/values.go
@@ -9,7 +9,6 @@ package codegen
 import (
 	"context"
 
-	"github.com/getoutreach/gobox/pkg/box"
 	gogit "github.com/go-git/go-git/v5"
 	stencilgit "go.rgst.io/stencil/internal/git"
 	"go.rgst.io/stencil/internal/modules"
@@ -30,9 +29,6 @@ type runtime struct {
 	// GeneratorVersion is the current version of the generator being
 	// used.
 	GeneratorVersion string
-
-	// Box is org wide configuration that is accessible if configured
-	Box *box.Config
 
 	// Modules contains a list of all modules that are being rendered
 	// in a stencil run
@@ -162,12 +158,6 @@ func NewValues(ctx context.Context, sm *configuration.Manifest, mods []*modules.
 			Name:    m.Name,
 			Version: m.Version,
 		})
-	}
-
-	var err error
-	vals.Runtime.Box, err = box.LoadBox()
-	if err != nil {
-		vals.Runtime.Box = &box.Config{}
 	}
 
 	// If we're a repository, add repository information

--- a/internal/codegen/values_test.go
+++ b/internal/codegen/values_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/getoutreach/gobox/pkg/box"
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
@@ -61,13 +60,6 @@ func TestValues(t *testing.T) {
 		Name: "testing",
 	}
 
-	boxConf, _ := box.LoadBox()
-	if boxConf == nil {
-		// Allows this test to pass when a user doesn't have a box
-		// configuration setup.
-		boxConf = &box.Config{}
-	}
-
 	vals := NewValues(context.Background(), sm, []*modules.Module{
 		{
 			Name: "testing",
@@ -87,7 +79,6 @@ func TestValues(t *testing.T) {
 		Runtime: runtime{
 			Generator:        "stencil",
 			GeneratorVersion: version.Version,
-			Box:              boxConf,
 			Modules: modulesSlice{
 				{
 					Name:    "testing",

--- a/internal/modules/module.go
+++ b/internal/modules/module.go
@@ -100,8 +100,8 @@ type NewModuleOpts struct {
 }
 
 // New creates a new module from a TemplateRepository. Version must be
-// set and can be obtained via the gobox/pkg/cli/updater/resolver
-// package, or by using the GetModulesForProject function.
+// set and can be obtained via the internal/modules/resolver package, or
+// by using the FetchModules function.
 //
 // uri is the URI for the module. If it is an empty string
 // https://+name is used instead.


### PR DESCRIPTION
The current box configuration implementation requires `gobox`, which
we're almost done removing from the dependency chain. As such, I'd like
to remove it.

My reasoning for doing so is that the current experience of `box`
creates gaps with open source repositories that are owned by an org,
causing those users to be unable to run `stencil` in those repositories,
normally resulting in an inability to build/run them.

I'd like to add box back later in another form, but for now it's best to
remove it and add it back later.

As far as I know, the current implementation also doesn't work in this
fork.
