### PR TITLE
build: upload apt/rpm/apk packages to fury.io for publishing

### DIFF
--- a/.github/scripts/fury-upload.sh
+++ b/.github/scripts/fury-upload.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 # FURY_PUSH_TOKEN is a secret token that is used to push packages to
 # fury (https://fury.io). It is a required environment variable.
-FURY_PUSH_TOKEN="${FURY_PUSH_TOKEN:-}"
+FURY_PUSH_TOKEN="${FURY_PUSH_TOKEN}"
 
 # allowed_exts is an array of allowed file extensions that can be
 # uploaded to fury.

--- a/.github/scripts/fury-upload.sh
+++ b/.github/scripts/fury-upload.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Originally adapated from:
+# https://github.com/goreleaser/goreleaser/blob/main/scripts/fury-upload.sh
+set -euo pipefail
+
+# FURY_PUSH_TOKEN is a secret token that is used to push packages to
+# fury (https://fury.io). It is a required environment variable.
+FURY_PUSH_TOKEN="${FURY_PUSH_TOKEN:-}"
+
+# allowed_exts is an array of allowed file extensions that can be
+# uploaded to fury.
+allowed_exts=("deb" "rpm" "apk")
+
+# Get the file extension
+file_ext="${1##*.}"
+
+is_allowed=false
+for ext in "${allowed_exts[@]}"; do
+  if [[ "$ext" == "$file_ext" ]]; then
+    is_allowed=true
+    break
+  fi
+done
+
+if [[ "$is_allowed" == "false" ]]; then
+  exit 0
+fi
+
+cd dist
+echo "uploading $1"
+status="$(curl -s -q -o /dev/null -w "%{http_code}" -F package="@$1" "https://${FURY_PUSH_TOKEN}@push.fury.io/rgst-io/")"
+echo "got: $status"
+if [[ "$status" == "200" ]] || [[ "$status" == "409" ]]; then
+  exit 0
+fi
+
+# Otherwise, exit with an error
+exit 1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -101,10 +101,11 @@ jobs:
           args: release --release-notes CHANGELOG.md --clean
         env:
           BUILD_RC: ${{ github.event.inputs.rc }}
+          FURY_PUSH_TOKEN: ${{ secrets.FURY_PUSH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ steps.homebrew-tap-github-app.outputs.token }}
           MACOS_SIGN_P12: ${{ secrets.MACOS_SIGN_P12 }}
           MACOS_SIGN_PASSWORD: ${{ secrets.MACOS_SIGN_PASSWORD }}
           MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
           MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
           MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_GITHUB_TOKEN: ${{ steps.homebrew-tap-github-app.outputs.token }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -111,7 +111,7 @@ publishers:
     env:
       - "FURY_PUSH_TOKEN={{ .Env.FURY_PUSH_TOKEN }}"
     cmd: ./.github/scripts/fury-upload.sh {{ .ArtifactName }}
-    disable: '{{ isEnvSet "FURY_PUSH_TOKEN" }}'
+    disable: '{{ if (isEnvSet "FURY_PUSH_TOKEN") }}false{{ else }}true{{ end }}'
 
 release:
   prerelease: "auto"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -104,6 +104,15 @@ nfpms:
         - statically-linked-binary
         - changelog-file-missing-in-native-package
 
+publishers:
+  - name: fury.io
+    ids:
+      - packages
+    env:
+      - "FURY_PUSH_TOKEN={{ .Env.FURY_PUSH_TOKEN }}"
+    cmd: ./.github/scripts/fury-upload.sh {{ .ArtifactName }}
+    disable: '{{ isEnvSet "FURY_PUSH_TOKEN" }}'
+
 release:
   prerelease: "auto"
   footer: |-


### PR DESCRIPTION
We're going to use `fury.io` to host our packages so users don't have to
manually download a `deb`, `rpm`, `apk` file everytime.
