### PR TITLE
build: attest generated archives

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -109,3 +109,8 @@ jobs:
           MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
           MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
           MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
+      - uses: actions/attest-build-provenance@v1
+        with:
+          # We attest all generated _archives_ because those are what we
+          # upload to Github Releases.
+          subject-path: dist/stencil_*.*, dist/checksums.txt


### PR DESCRIPTION
This allows us to prove that archives created on releases were created
by a specific CI run.
