### PR TITLE
build: use latest version of stencil-golang

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,6 @@ root = true
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true
-max_line_length = 72
 indent_style = tab
 
 # yaml is forced to use spaces :/

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      ## <<Stencil::Block(releaseSetup)>>
       - uses: actions/create-github-app-token@v1
         id: homebrew-tap-github-app
         with:
@@ -36,6 +37,7 @@ jobs:
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: homebrew-tap
+      ## <</Stencil::Block>>
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -68,8 +70,10 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: fregante/setup-git-user@v2
-      - uses: anchore/sbom-action/download-syft@v0.16.1
+      - name: Set up git user
+        uses: fregante/setup-git-user@v2
+      - name: Download syft (SBOM)
+        uses: anchore/sbom-action/download-syft@v0.16.1
 
       # Bumping logic
       - name: Get next version
@@ -79,14 +83,6 @@ jobs:
           VERSION_OVERRIDE: ${{ github.event.inputs.version }}
         run: |-
           echo "version=$(./.github/scripts/get-next-version.sh)" >> "$GITHUB_OUTPUT"
-      - name: Wait for manual approval
-        uses: trstringer/manual-approval@v1
-        # Skip if the triggering actor is the same as the approver
-        if: github.triggering_actor != 'jaredallard'
-        with:
-          secret: ${{ secrets.GITHUB_TOKEN }}
-          approvers: "jaredallard"
-          issue-title: "Release ${{ steps.next_version.outputs.version }}"
       - name: Create Tag
         run: |-
           git tag -a "${{ steps.next_version.outputs.version }}" -m "Release ${{ steps.next_version.outputs.version }}"
@@ -100,15 +96,17 @@ jobs:
           version: v${{ steps.goreleaser.outputs.version }}
           args: release --release-notes CHANGELOG.md --clean
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ## <<Stencil::Block(goreleaseEnvVars)>>
           BUILD_RC: ${{ github.event.inputs.rc }}
           FURY_PUSH_TOKEN: ${{ secrets.FURY_PUSH_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ steps.homebrew-tap-github-app.outputs.token }}
           MACOS_SIGN_P12: ${{ secrets.MACOS_SIGN_P12 }}
           MACOS_SIGN_PASSWORD: ${{ secrets.MACOS_SIGN_PASSWORD }}
           MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
           MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
           MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
+          ## <</Stencil::Block>>
       - uses: actions/attest-build-provenance@v1
         with:
           # We attest all generated _archives_ because those are what we

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,3 +1,5 @@
+# TODO(jaredallard): Deviated from stencil-golang.
+# Removed golangci-lint because we put it in linters.yaml
 name: tests
 on:
   push:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,12 +1,12 @@
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
-# vim: set ts=2 sw=2 tw=0 fo=cnqoj
 version: 2
 project_name: stencil
-
+before:
+  hooks:
+    - go mod tidy
 report_sizes: true
 metadata:
   mod_timestamp: "{{ .CommitTimestamp }}"
-
 builds:
   - main: ./cmd/{{ .ProjectName }}
     flags:
@@ -14,42 +14,45 @@ builds:
     ldflags:
       - -s
       - -w
+      ## <<Stencil::Block(ldflags)>>
       - -X go.rgst.io/stencil/internal/version.version={{.Version}}
       - -X go.rgst.io/stencil/internal/version.commit={{.Commit}}
       - -X go.rgst.io/stencil/internal/version.date={{ .CommitDate }}
       - -X go.rgst.io/stencil/internal/version.builtBy=goreleaser
       - -X go.rgst.io/stencil/internal/version.treeState={{ if .IsGitDirty }}dirty{{ else }}clean{{ end }}
+      ## <</Stencil::Block>>
     env:
       - CGO_ENABLED=0
     goarch:
-      - "386"
       - amd64
-      - arm
       - arm64
+      ## <<Stencil::Block(extraArch)>>
+      - "386"
+      - arm
       - ppc64
+      ## <</Stencil::Block>>
     goos:
       - linux
       - darwin
+      ## <<Stencil::Block(extraOS)>>
       - windows
-    goarm:
-      - "7"
+      ## <</Stencil::Block>>
     ignore:
       - goos: windows
         goarch: arm
     mod_timestamp: "{{ .CommitTimestamp }}"
-archives:
-  - format: tar.xz
-    format_overrides:
-      - format: zip
-        goos: windows
 checksum:
   name_template: "checksums.txt"
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
-
 changelog:
   use: git
+release:
+  prerelease: "auto"
+  footer: |-
+    **Full Changelog**: https://github.com/rgst-io/stencil/compare/{{ .PreviousTag }}...{{ .Tag }}
 
+## <<Stencil::Block(extraReleaseOpts)>>
 # ---------- Packaging
 notarize:
   macos:
@@ -112,8 +115,4 @@ publishers:
       - "FURY_PUSH_TOKEN={{ .Env.FURY_PUSH_TOKEN }}"
     cmd: ./.github/scripts/fury-upload.sh {{ .ArtifactName }}
     disable: '{{ if (isEnvSet "FURY_PUSH_TOKEN") }}false{{ else }}true{{ end }}'
-
-release:
-  prerelease: "auto"
-  footer: |-
-    **Full Changelog**: https://github.com/rgst-io/stencil/compare/{{ .PreviousTag }}...{{ .Tag }}
+## <</Stencil::Block>>

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,13 +1,15 @@
+
 # Default versions of tools, to update these, set [tools.override]
 [tools]
-golang = "1.22"
 git-cliff = "latest"
+golang = "1.22"
 golangci-lint = "1.59"
 goreleaser = "latest"
-bun = "latest"
-"go:mvdan.cc/sh/v3/cmd/shfmt" = "latest"
 "go:gotest.tools/gotestsum" = "v1.12.0"
 "go:golang.org/x/tools/cmd/goimports" = "latest"
+"go:mvdan.cc/sh/v3/cmd/shfmt" = "latest"
+# TODO(jaredallard): Deviated from stencil-golang.
+bun = "latest"
 "go:github.com/thenativeweb/get-next-version" = "latest"
 "go:sigs.k8s.io/mdtoc" = "latest"
 
@@ -15,13 +17,10 @@ bun = "latest"
 description = "Build a binary for the current platform/architecture"
 run = "go build -trimpath -o ./bin/ -v ./cmd/..."
 
-[tasks.test]
-description = "Run tests"
-run = "gotestsum"
-
-[tasks.lint]
-description = "Run linters"
-run = "golangci-lint run"
+[tasks.changelog]
+description = "Generate a changelog for the current version"
+outputs = ["CHANGELOG.md"]
+run = ["git-cliff --config .cliff.toml --output CHANGELOG.md"]
 
 [tasks.fmt]
 alias = "format"
@@ -31,8 +30,23 @@ run = [
 	"gofmt -s -w .",
 	"goimports -w .",
 	"shfmt -w .",
+	# TODO(jaredallard): Deviated from stencil-golang.
 	"bun node_modules/.bin/prettier --write '**/*.{json,yaml,yml,md,jsonschema.json}'",
 ]
+
+[tasks.lint]
+description = "Run linters"
+run = "golangci-lint run"
+
+[tasks.next-version]
+description = """Get the version number that would be released if a release was ran right now.
+Pass --rc to get the next release candidate version.
+"""
+run = ["./.github/scripts/get-next-version.sh"]
+
+[tasks.test]
+description = "Run tests"
+run = "gotestsum"
 
 ## <<Stencil::Block(custom)>>
 [tasks.generate]
@@ -47,20 +61,9 @@ run = "go run ./tools/docgen/docgen.go"
 description = "Generate JSON schema files for stencil configuration files"
 run = "go run ./tools/schemagen/schemagen.go"
 
-[tasks.next-version]
-description = """Get the version number that would be released if a release was ran right now.
-Pass --rc to get the next release candidate version.
-"""
-run = ["./.github/scripts/get-next-version.sh"]
-
 [tasks.update-readme-toc]
 description = "Update the TOC in the README"
 run = ["mdtoc --inplace --max-depth=5 README.md"]
-
-[tasks.changelog]
-description = "Generate a changelog for the current version"
-outputs = ["CHANGELOG.md"]
-run = ["git-cliff --config .cliff.toml --output CHANGELOG.md"]
 
 [settings]
 # Conflicts with bun, and we don't use it anyways.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+	// TODO(jaredallard): Deviated from stencil-golang.
 	"go.lintTool": "golangci-lint",
 	"go.formatTool": "goimports",
 	"go.useLanguageServer": true,
@@ -15,13 +16,7 @@
 	"gopls": {
 		"build.buildFlags": ["-tags=or_dev"]
 	},
-	"cSpell.words": [
-		"codegen",
-		"getoutreach",
-		"gogit",
-		"templating",
-		"worktree"
-	],
+	"cSpell.words": ["codegen", "getoutreach", "gogit", "templating", "worktree"],
 
 	// Schema support OOTB.
 	"yaml.schemas": {

--- a/go.work.sum
+++ b/go.work.sum
@@ -2108,6 +2108,7 @@ github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdh
 github.com/schollz/progressbar/v3 v3.14.1/go.mod h1:Zc9xXneTzWXF81TGoqL71u0sBPjULtEHYtj/WVgVy8E=
 github.com/schollz/progressbar/v3 v3.14.3 h1:oOuWW19ka12wxYU1XblR4n16wF/2Y1dBLMarMo6p4xU=
 github.com/schollz/progressbar/v3 v3.14.3/go.mod h1:aT3UQ7yGm+2ZjeXPqsjTenwL3ddUiuZ0kfQ/2tHlyNI=
+github.com/schollz/progressbar/v3 v3.14.4/go.mod h1:aT3UQ7yGm+2ZjeXPqsjTenwL3ddUiuZ0kfQ/2tHlyNI=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
@@ -2253,6 +2254,7 @@ go.opentelemetry.io/otel v1.23.0/go.mod h1:YCycw9ZeKhcJFrb34iVSkyT0iczq/zYDtZYFu
 go.opentelemetry.io/otel v1.24.0/go.mod h1:W7b9Ozg4nkF5tWI5zsXkaKKDjdVjpD4oAt9Qi/MArHo=
 go.opentelemetry.io/otel v1.27.0 h1:9BZoF3yMK/O1AafMiQTVu0YDj5Ea4hPhxCs7sGva+cg=
 go.opentelemetry.io/otel v1.27.0/go.mod h1:DMpAK8fzYRzs+bi3rS5REupisuqTheUlSZJ1WnZaPAQ=
+go.opentelemetry.io/otel v1.28.0/go.mod h1:q68ijF8Fc8CnMHKyzqL6akLO46ePnjkgfIMIjUIX9z4=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.21.0/go.mod h1:zgBdWWAu7oEEMC06MMKc5NLbA/1YDXV1sMpSqEeLQLg=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.24.0 h1:t6wl9SPayj+c7lEIFgm4ooDBZVb01IhLB4InpomhRw8=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.24.0/go.mod h1:iSDOcsnSA5INXzZtwaBPrKp/lWu/V14Dd+llD0oI2EA=
@@ -2266,6 +2268,7 @@ go.opentelemetry.io/otel/metric v1.23.0/go.mod h1:MqUW2X2a6Q8RN96E2/nqNoT+z9BSms
 go.opentelemetry.io/otel/metric v1.24.0/go.mod h1:VYhLe1rFfxuTXLgj4CBiyz+9WYBA8pNGJgDcSFRKBco=
 go.opentelemetry.io/otel/metric v1.27.0 h1:hvj3vdEKyeCi4YaYfNjv2NUje8FqKqUY8IlF0FxV/ik=
 go.opentelemetry.io/otel/metric v1.27.0/go.mod h1:mVFgmRlhljgBiuk/MP/oKylr4hs85GZAylncepAX/ak=
+go.opentelemetry.io/otel/metric v1.28.0/go.mod h1:Fb1eVBFZmLVTMb6PPohq3TO9IIhUisDsbJoL/+uQW4s=
 go.opentelemetry.io/otel/sdk v1.19.0/go.mod h1:NedEbbS4w3C6zElbLdPJKOpJQOrGUJ+GfzpjUvI0v1A=
 go.opentelemetry.io/otel/sdk v1.21.0/go.mod h1:Nna6Yv7PWTdgJHVRD9hIYywQBRx7pbox6nwBnZIxl/E=
 go.opentelemetry.io/otel/sdk v1.22.0/go.mod h1:iu7luyVGYovrRpe2fmj3CVKouQNdTOkxtLzPvPz1DOc=
@@ -2279,6 +2282,7 @@ go.opentelemetry.io/otel/trace v1.23.0/go.mod h1:GSGTbIClEsuZrGIzoEHqsVfxgn5Ukgg
 go.opentelemetry.io/otel/trace v1.24.0/go.mod h1:HPc3Xr/cOApsBI154IU0OI0HJexz+aw5uPdbs3UCjNU=
 go.opentelemetry.io/otel/trace v1.27.0 h1:IqYb813p7cmbHk0a5y6pD5JPakbVfftRXABGt5/Rscw=
 go.opentelemetry.io/otel/trace v1.27.0/go.mod h1:6RiD1hkAprV4/q+yd2ln1HG9GoPx39SuvvstaLBl+l4=
+go.opentelemetry.io/otel/trace v1.28.0/go.mod h1:jPyXzNPg6da9+38HEwElrQiHlVMTnVfM3/yv2OlIHaI=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.opentelemetry.io/proto/otlp v0.15.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=
 go.opentelemetry.io/proto/otlp v0.19.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=
@@ -2402,6 +2406,7 @@ golang.org/x/mod v0.14.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/mod v0.15.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/mod v0.17.0 h1:zY54UmvipHiNd+pm+m0x9KhZ9hl1/7QNMyxXbc6ICqA=
 golang.org/x/mod v0.17.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+golang.org/x/mod v0.19.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181023162649-9b4f9f5ad519/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -2756,6 +2761,7 @@ golang.org/x/tools v0.14.0/go.mod h1:uYBEerGOWcJyEORxN+Ek8+TT266gXkNlHdJBwexUsBg
 golang.org/x/tools v0.16.0/go.mod h1:kYVVN6I1mBNoB1OX+noeBjbRk4IUEPa7JJ+TJMEooJ0=
 golang.org/x/tools v0.21.0 h1:qc0xYgIbsSDt9EyWz05J5wfa7LOVW0YTLOXrqdLAWIw=
 golang.org/x/tools v0.21.0/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk=
+golang.org/x/tools v0.23.0/go.mod h1:pnu6ufv6vQkll6szChhK3C3L/ruaIv5eBeztNG8wtsI=
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -69,8 +69,9 @@ type Manifest struct {
 	Arguments map[string]interface{} `yaml:"arguments"`
 
 	// Replacements is a list of module names to replace their URI.
+	//
 	// Expected format:
-	// - local file: file://path/to/module
+	// - local file: path/to/module
 	// - remote file: https://github.com/getoutreach/stencil-base
 	Replacements map[string]string `yaml:"replacements,omitempty"`
 }

--- a/schemas/stencil.jsonschema.json
+++ b/schemas/stencil.jsonschema.json
@@ -26,7 +26,7 @@
 				"replacements": {
 					"additionalProperties": { "type": "string" },
 					"type": "object",
-					"description": "Replacements is a list of module names to replace their URI.\nExpected format:\n- local file: file://path/to/module\n- remote file: https://github.com/getoutreach/stencil-base"
+					"description": "Replacements is a list of module names to replace their URI.\n\nExpected format:\n- local file: path/to/module\n- remote file: https://github.com/getoutreach/stencil-base"
 				}
 			},
 			"additionalProperties": false,

--- a/stencil.lock
+++ b/stencil.lock
@@ -1,11 +1,20 @@
-version: v0.0.0-dev
+version: devel
 modules:
     - name: github.com/rgst-io/stencil-golang
       url: https://github.com/rgst-io/stencil-golang
       version:
-        commit: 3c3213721335c53fd78f4fede1b3704801616615
-        tag: v0.5.0
+        commit: 553b465e2e6fb0f3ce71a6e2b9add52e8513eb62
+        branch: main
 files:
+    - name: .cliff.toml
+      template: .cliff.toml.tpl
+      module: github.com/rgst-io/stencil-golang
+    - name: .editorconfig
+      template: .editorconfig.tpl
+      module: github.com/rgst-io/stencil-golang
+    - name: .github/scripts/get-next-version.sh
+      template: .github/scripts/get-next-version.sh.tpl
+      module: github.com/rgst-io/stencil-golang
     - name: .github/settings.yml
       template: .github/settings.yml.tpl
       module: github.com/rgst-io/stencil-golang
@@ -20,6 +29,9 @@ files:
       module: github.com/rgst-io/stencil-golang
     - name: .mise.toml
       template: .mise.toml.tpl
+      module: github.com/rgst-io/stencil-golang
+    - name: .mise/tasks/changelog-release
+      template: .mise/tasks/changelog-release.tpl
       module: github.com/rgst-io/stencil-golang
     - name: .vscode/extensions.json
       template: .vscode/extensions.json.tpl

--- a/stencil.yaml
+++ b/stencil.yaml
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=./.vscode/schema.json
 name: stencil
 arguments:
   org: rgst-io
   license: Apache-2.0
 modules:
   - name: github.com/rgst-io/stencil-golang
+    version: main


### PR DESCRIPTION
Uprades to the latest version of `stencil-golang` that supports most of
what we deviated from previously.
