### PR TITLE
fix: file.Delete should delete lockfile history, if any exists

### DIFF
--- a/internal/codegen/tpl_file.go
+++ b/internal/codegen/tpl_file.go
@@ -85,9 +85,12 @@ func (f *TplFile) Skip(reason string) (output string, err error) {
 // Delete deletes the current file being rendered
 //
 //	{{ file.Delete }}
-func (f *TplFile) Delete() error {
+func (f *TplFile) Delete() (out string, err error) {
+	if f.lock != nil {
+		f.lock.Files = slices.DeleteFunc(f.lock.Files, func(ff *stencil.LockfileFileEntry) bool { return ff.Name == f.f.path })
+	}
 	f.f.Deleted = true
-	return nil
+	return "", nil
 }
 
 // Static marks the current file as static

--- a/internal/codegen/tpl_file_test.go
+++ b/internal/codegen/tpl_file_test.go
@@ -13,6 +13,70 @@ import (
 	"gotest.tools/v3/assert"
 )
 
+// TestTplFile_DeleteNoLockfile tests the file.Delete command when there's no lockfile history at all
+func TestTplFile_DeleteNoLockfile(t *testing.T) {
+	tplf := TplFile{
+		f: &File{path: "test.go"},
+	}
+
+	fo, err := tplf.Delete()
+	assert.NilError(t, err)
+	assert.Equal(t, "", fo)
+	assert.Equal(t, true, tplf.f.Deleted)
+}
+
+// TestTplFile_DeleteLockfileNoHistory tests the file.Delete command when there's a lockfile with no history of the file
+func TestTplFile_DeleteLockfileNoHistory(t *testing.T) {
+	tplf := TplFile{
+		f: &File{path: "test.go"},
+		lock: &stencil.Lockfile{
+			Files: []*stencil.LockfileFileEntry{},
+		},
+	}
+
+	fo, err := tplf.Delete()
+	assert.NilError(t, err)
+	assert.Equal(t, "", fo)
+	assert.Equal(t, true, tplf.f.Deleted)
+	assert.Equal(t, 0, len(tplf.lock.Files))
+}
+
+// TestTplFile_DeleteLockfileHistory tests the file.Delete command when there's a lockfile with history of the file
+func TestTplFile_DeleteLockfileHistory(t *testing.T) {
+	tplf := TplFile{
+		f: &File{path: "test.go"},
+		lock: &stencil.Lockfile{
+			Files: []*stencil.LockfileFileEntry{
+				{Name: "test.go"},
+			},
+		},
+	}
+
+	fo, err := tplf.Delete()
+	assert.NilError(t, err)
+	assert.Equal(t, "", fo)
+	assert.Equal(t, true, tplf.f.Deleted)
+	assert.Equal(t, 0, len(tplf.lock.Files))
+}
+
+// TestTplFile_DeleteLockfileHistoryOfOther tests the file.Delete command when there's a lockfile with history of another file
+func TestTplFile_DeleteLockfileHistoryOfOther(t *testing.T) {
+	tplf := TplFile{
+		f: &File{path: "test.go"},
+		lock: &stencil.Lockfile{
+			Files: []*stencil.LockfileFileEntry{
+				{Name: "foo.go"},
+			},
+		},
+	}
+
+	fo, err := tplf.Delete()
+	assert.NilError(t, err)
+	assert.Equal(t, "", fo)
+	assert.Equal(t, true, tplf.f.Deleted)
+	assert.Equal(t, 1, len(tplf.lock.Files))
+}
+
 // TestTplFile_OnceNoLockfile tests the file.Once command when there's no lockfile history at all
 func TestTplFile_OnceNoLockfile(t *testing.T) {
 	tplf := TplFile{


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers
