### PR TITLE
test: remove need to compile self

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
 	"go.formatTool": "goimports",
 	"go.useLanguageServer": true,
 	"go.buildTags": "or_dev",
+	"go.testFlags": ["-v"],
 	"files.trimTrailingWhitespace": true,
 	"editor.formatOnSave": true,
 	"shellcheck.customArgs": ["-P", "SCRIPTDIR", "-x"],

--- a/cmd/stencil/create.go
+++ b/cmd/stencil/create.go
@@ -6,17 +6,18 @@ package main
 
 import (
 	"github.com/urfave/cli/v2"
+	"go.rgst.io/stencil/pkg/slogext"
 )
 
 // NewCreateCommand returns a new urfave/cli.Command for the
 // create command
-func NewCreateCommand() *cli.Command {
+func NewCreateCommand(log slogext.Logger) *cli.Command {
 	return &cli.Command{
 		Name:        "create",
 		Usage:       "create a new stencil project or module",
 		Description: "Commands to create template repositories, or stencil powered repositories",
 		Subcommands: []*cli.Command{
-			NewCreateModuleCommand(),
+			NewCreateModuleCommand(log),
 		},
 	}
 }

--- a/cmd/stencil/create_module.go
+++ b/cmd/stencil/create_module.go
@@ -15,20 +15,21 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
-	"os/exec"
 	"path"
 
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
 	"go.rgst.io/stencil/pkg/configuration"
+	"go.rgst.io/stencil/pkg/slogext"
 	"gopkg.in/yaml.v3"
 )
 
 // NewCreateModuleCommand returns a new urfave/cli.Command for the
 // create module command.
-func NewCreateModuleCommand() *cli.Command {
+func NewCreateModuleCommand(log slogext.Logger) *cli.Command {
 	return &cli.Command{
 		Name:        "module",
 		Description: "Creates a module with the provided name in the current directory",
@@ -75,12 +76,8 @@ func NewCreateModuleCommand() *cli.Command {
 				return err
 			}
 
-			//nolint:gosec // Why: intentional
-			cmd := exec.CommandContext(c.Context, os.Args[0])
-			cmd.Stdout = os.Stdout
-			cmd.Stderr = os.Stderr
-			cmd.Stdin = os.Stdin
-			return errors.Wrap(cmd.Run(), "failed to run stencil")
+			// Run the standard stencil command.
+			return NewStencilAction(log)(cli.NewContext(c.App, flag.NewFlagSet("", flag.ExitOnError), c))
 		},
 	}
 }

--- a/cmd/stencil/lockfile_prune.go
+++ b/cmd/stencil/lockfile_prune.go
@@ -29,6 +29,7 @@ import (
 func NewLockfilePruneCommand(log slogext.Logger) *cli.Command {
 	return &cli.Command{
 		Name:        "prune",
+		Usage:       "Prunes non-existent files from the lockfile",
 		Description: "Prunes any non-existent files from the lockfile (will recreate any file.Once files on next run)",
 
 		Flags: []cli.Flag{


### PR DESCRIPTION
Instead of executing ourself, we use `NewStencilAction` and chain it
during `create module`. This should decrease the time to run tests, but
sadly we still need `chdir`, so we can't parallelize the tests (yet...)
