### PR TITLE
feat(codegen)!: ApplyTemplate data is on .Data

### DIFF
--- a/docs/functions/stencil.ApplyTemplate.md
+++ b/docs/functions/stencil.ApplyTemplate.md
@@ -6,9 +6,18 @@ order: 1012
 
 # stencil.ApplyTemplate
 
-ApplyTemplate executes a template inside of the current module
+ApplyTemplate executes a named template (defined through the `define`
+function) with the provided optional data.
 
-This function does not support rendering a template from another module.
+The provided data can be accessed within the defined template under the
+`.Data` key.
+
+`.` is a copy of [Values](#Values)for the calling template, meaning it is not mutated to reflect that of
+the template being rendered.
+
+## Examples
+
+### Without Data
 
 ```go
 {{- define "command"}}
@@ -23,4 +32,24 @@ func main() {
 {{- end }}
 
 {{- stencil.ApplyTemplate "command" | file.SetContents }}
+```
+
+### With Data
+
+```go
+{{- define "command"}}
+{{- $cliName := .Data }}
+package main
+
+import "fmt"
+
+func main() {
+		fmt.Println("hello from {{ $cliName }}!")
+}
+
+{{- end }}
+
+{{- range $cliName := stencil.Arg "clis" }}
+{{- stencil.ApplyTemplate "command" $cliName | file.SetContents }}
+{{- end }}
 ```

--- a/internal/codegen/testdata/multi-file-input.tpl
+++ b/internal/codegen/testdata/multi-file-input.tpl
@@ -1,5 +1,5 @@
 {{- define "command" }}
-{{- . }}
+{{- .Data }}
 {{- end }}
 
 # Generate a "<commandName>.go" file for each command in .arguments.commands

--- a/internal/codegen/tpl_stencil.go
+++ b/internal/codegen/tpl_stencil.go
@@ -286,7 +286,9 @@ func (s *TplStencil) ApplyTemplate(name string, dataSli ...any) (string, error) 
 	// Create a copy of the current values so we can set the data on it
 	// without mutating the original values.
 	d := s.t.args.Copy()
-	d.Data = dataSli
+	if len(dataSli) > 0 {
+		d.Data = dataSli[0]
+	}
 
 	var buf bytes.Buffer
 	if err := s.t.Module.GetTemplate().ExecuteTemplate(&buf, name, d); err != nil {

--- a/internal/codegen/tpl_stencil_test.go
+++ b/internal/codegen/tpl_stencil_test.go
@@ -280,7 +280,7 @@ func TestTplStencil_ApplyTemplate(t *testing.T) {
 				name:    "hello-world",
 				dataSli: []any{"xyz"},
 			},
-			subTemplate: `{{- define "hello-world" -}}{{ . }}{{- end -}}`,
+			subTemplate: `{{- define "hello-world" -}}{{ .Data }}{{- end -}}`,
 			want:        "xyz",
 		},
 		{

--- a/internal/codegen/tpl_stencil_test.go
+++ b/internal/codegen/tpl_stencil_test.go
@@ -1,12 +1,14 @@
 package codegen
 
 import (
+	"context"
 	"os"
 	"reflect"
 	"testing"
 	"time"
 
 	"github.com/go-git/go-billy/v5"
+	"go.rgst.io/stencil/internal/modules"
 	"go.rgst.io/stencil/internal/modules/modulestest"
 	"go.rgst.io/stencil/pkg/configuration"
 	"go.rgst.io/stencil/pkg/slogext"
@@ -243,4 +245,98 @@ func TestTplStencil_ReadFile(t *testing.T) {
 	// fails when file doesn't exist
 	_, err = s.ReadFile("file/that/doesnt/exist")
 	assert.Error(t, err, `file "file/that/doesnt/exist" does not exist`)
+}
+
+func TestTplStencil_ApplyTemplate(t *testing.T) {
+	type args struct {
+		name    string
+		dataSli []interface{}
+	}
+	tests := []struct {
+		name        string
+		args        args
+		subTemplate string
+		want        string
+		wantErr     bool
+	}{
+		{
+			name: "should error on non-existent template",
+			args: args{
+				name: "non-existent",
+			},
+			wantErr: true,
+		},
+		{
+			name: "should render a template",
+			args: args{
+				name: "hello-world",
+			},
+			subTemplate: `{{- define "hello-world" -}}{{ "Hello, world!" }}{{- end -}}`,
+			want:        "Hello, world!",
+		},
+		{
+			name: "should support data",
+			args: args{
+				name:    "hello-world",
+				dataSli: []any{"xyz"},
+			},
+			subTemplate: `{{- define "hello-world" -}}{{ . }}{{- end -}}`,
+			want:        "xyz",
+		},
+		{
+			name: "should pass through data from parent template",
+			args: args{
+				name:    "hello-world",
+				dataSli: []any{"xyz"},
+			},
+			subTemplate: `{{- define "hello-world" -}}{{ .Config.Name }}{{- end -}}`,
+			want:        "TestTplStencil_ApplyTemplate/should_pass_through_data_from_parent_template",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			log := slogext.NewTestLogger(t)
+
+			// create stencil
+			st := &Stencil{sharedData: &sharedData{globals: make(map[string]global)}}
+
+			// create module
+			module, err := modulestest.NewModuleFromTemplates(&configuration.TemplateRepositoryManifest{
+				Name: "test",
+			})
+			assert.NilError(t, err, "expected NewModuleFromTemplates to succeed")
+
+			// create template for module
+			tpl, err := NewTemplate(
+				module,
+				"not-a-real-template.tpl",
+				0o755,
+				time.Now(),
+				[]byte(tt.subTemplate),
+				log,
+			)
+			assert.NilError(t, err, "expected NewTemplate to succeed")
+
+			// render template to register it
+			tpl.Render(st,
+				NewValues(context.Background(), &configuration.Manifest{
+					Name: t.Name(),
+				}, []*modules.Module{module}),
+			)
+
+			s := &TplStencil{
+				t:   tpl,
+				s:   st,
+				log: log,
+			}
+			got, err := s.ApplyTemplate(tt.args.name, tt.args.dataSli...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("TplStencil.ApplyTemplate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("TplStencil.ApplyTemplate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/internal/codegen/values.go
+++ b/internal/codegen/values.go
@@ -107,8 +107,9 @@ func (m modulesSlice) ByName(name string) module {
 	return module{}
 }
 
-// Values is the top level container for variables being
-// passed to a stencil template.
+// Values is the top level container for variables being passed to a
+// stencil template. When updating this struct, ensure that the receiver
+// functions are updated to reflect the new fields.
 type Values struct {
 	// Git is information about the current git repository, if there is one
 	Git git
@@ -124,12 +125,29 @@ type Values struct {
 
 	// Template is the name of the template being rendered
 	Template stencilTemplate
+
+	// Data is only available when a template is being rendered through
+	// stencil.ApplyTemplate. It contains the data passed through said
+	// call.
+	Data any
 }
 
 // Copy returns a copy of the current values
 func (v *Values) Copy() *Values {
 	nv := *v
 	return &nv
+}
+
+// CopyMap returns a copy of the current values as a map
+func (v *Values) CopyMap() map[string]interface{} {
+	c := v.Copy()
+	return map[string]any{
+		"Git":      c.Git,
+		"Runtime":  c.Runtime,
+		"Config":   c.Config,
+		"Module":   c.Module,
+		"Template": c.Template,
+	}
 }
 
 // WithModule returns a copy of the current values with the

--- a/internal/codegen/values.go
+++ b/internal/codegen/values.go
@@ -138,18 +138,6 @@ func (v *Values) Copy() *Values {
 	return &nv
 }
 
-// CopyMap returns a copy of the current values as a map
-func (v *Values) CopyMap() map[string]interface{} {
-	c := v.Copy()
-	return map[string]any{
-		"Git":      c.Git,
-		"Runtime":  c.Runtime,
-		"Config":   c.Config,
-		"Module":   c.Module,
-		"Template": c.Template,
-	}
-}
-
 // WithModule returns a copy of the current values with the
 // provided module information being set.
 func (v *Values) WithModule(name string, ver *resolver.Version) *Values {

--- a/internal/modules/nativeext/apiv1/client.go
+++ b/internal/modules/nativeext/apiv1/client.go
@@ -23,8 +23,10 @@ func NewExtensionClient(ctx context.Context, extPath string, log slogext.Logger)
 	// create a connection to the extension
 	client := plugin.NewClient(&plugin.ClientConfig{
 		Logger: hclog.New(&hclog.LoggerOptions{
-			Level:       hclog.Trace,
-			Output:      &logger{fn: func(args ...interface{}) { log.Debugf("%s", args...) }},
+			Level: hclog.Trace,
+			Output: &logger{fn: func(args ...interface{}) {
+				log.Debug(fmt.Sprint(args...))
+			}},
 			DisableTime: true,
 		}),
 		HandshakeConfig: plugin.HandshakeConfig{


### PR DESCRIPTION
Data is moved from `.` to `.Data` to allow for passing parent template
values always. This also enables function recievers to always be passed
as well, in the case of having to do the `dict "Config" .Config` hack
that existed before.
