### PR TITLE
feat(create-module): use stencil-golang to create modules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,7 +28,7 @@ linters:
     - errcheck
     - errorlint
     - exhaustive # Checks exhaustiveness of enum switch statements.
-    - exportloopref # Checks for pointers to enclosing loop variables.
+    - copyloopvar
     - funlen
     - gochecknoinits
     - goconst

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,6 @@
 	"go.lintTool": "golangci-lint",
 	"go.formatTool": "goimports",
 	"go.useLanguageServer": true,
-	"go.buildTags": "or_dev",
 	"go.testFlags": ["-v"],
 	"files.trimTrailingWhitespace": true,
 	"editor.formatOnSave": true,
@@ -13,9 +12,6 @@
 	},
 	"[yaml]": {
 		"editor.defaultFormatter": "redhat.vscode-yaml"
-	},
-	"gopls": {
-		"build.buildFlags": ["-tags=or_dev"]
 	},
 	"cSpell.words": ["codegen", "getoutreach", "gogit", "templating", "worktree"],
 

--- a/cmd/stencil/create_module.go
+++ b/cmd/stencil/create_module.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
@@ -27,6 +28,62 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// encodeToFile encodes the provided data [d] to the provided file path,
+// it is done by streaming to the created file.
+func encodeToFile(d any, outputFilePath string) error {
+	f, err := os.Create(outputFilePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	enc := yaml.NewEncoder(f)
+	if err := enc.Encode(d); err != nil {
+		return err
+	}
+
+	return enc.Close()
+}
+
+// generateTemplateRepository generates a template repository manifest
+// (manifest.yaml) based on the provided input.
+func generateTemplateRepository(name string, hasPlugin bool) *configuration.TemplateRepositoryManifest {
+	tr := &configuration.TemplateRepositoryManifest{
+		Name: name,
+	}
+
+	tr.Type = configuration.TemplateRepositoryTypes{}
+	if hasPlugin {
+		tr.Type = append(tr.Type, configuration.TemplateRepositoryTypeTemplates, configuration.TemplateRepositoryTypeExt)
+	}
+
+	return tr
+}
+
+// generateStencilYaml generates a stencil.yaml manifest based on the
+// provided input.
+func generateStencilYaml(name string, hasPlugin bool) *configuration.Manifest {
+	mf := &configuration.Manifest{
+		Name: path.Base(name),
+		Modules: []*configuration.TemplateRepository{{
+			Name: "github.com/rgst-io/stencil-module",
+		}},
+		Arguments: map[string]any{
+			"org": strings.Split(strings.TrimPrefix(name, "github.com/"), "/")[0],
+		},
+	}
+
+	if hasPlugin {
+		mf.Arguments["commands"] = []string{
+			"plugin",
+		}
+	} else {
+		mf.Arguments["library"] = true
+	}
+
+	return mf
+}
+
 // NewCreateModuleCommand returns a new urfave/cli.Command for the
 // create module command.
 func NewCreateModuleCommand(log slogext.Logger) *cli.Command {
@@ -34,12 +91,30 @@ func NewCreateModuleCommand(log slogext.Logger) *cli.Command {
 		Name:        "module",
 		Description: "Creates a module with the provided name in the current directory",
 		ArgsUsage:   "create module <name>",
+		Flags: []cli.Flag{
+			&cli.StringSliceFlag{
+				Name:  "type",
+				Usage: "The type of module to create",
+				Value: cli.NewStringSlice("templates"),
+			},
+		},
 		Action: func(c *cli.Context) error {
-			var manifestFileName = "stencil.yaml"
+			var stencilManifestName = "stencil.yaml"
 
 			// ensure we have a name
 			if c.NArg() != 1 {
 				return errors.New("must provide a name for the module")
+			}
+
+			moduleName := c.Args().Get(0)
+			hasPlugin := false
+
+			// stencil-golang requires Github right now, so it doesn't make
+			// sense to generate broken templates on some other VCS provider.
+			// Note that you can still have template modules on, say, Gitlab,
+			// but we just can't generate them (yet!).
+			if !strings.HasPrefix(moduleName, "github.com/") {
+				return fmt.Errorf("currently, only github based modules are supported")
 			}
 
 			allowedFiles := map[string]struct{}{
@@ -58,26 +133,26 @@ func NewCreateModuleCommand(log slogext.Logger) *cli.Command {
 				}
 			}
 
-			tm := &configuration.Manifest{
-				Name: path.Base(c.Args().Get(0)),
+			// create stencil.yaml
+			if err := encodeToFile(generateStencilYaml(moduleName, hasPlugin), stencilManifestName); err != nil {
+				return fmt.Errorf("failed to serialize %s: %w", stencilManifestName, err)
 			}
 
-			f, err := os.Create(manifestFileName)
-			if err != nil {
-				return err
-			}
-			defer f.Close()
-
-			enc := yaml.NewEncoder(f)
-			if err := enc.Encode(tm); err != nil {
-				return err
-			}
-			if err := enc.Close(); err != nil {
-				return err
+			if err := encodeToFile(generateTemplateRepository(moduleName, hasPlugin), "manifest.yaml"); err != nil {
+				return fmt.Errorf("failed to serialize generated manifest.yaml: %w", err)
 			}
 
 			// Run the standard stencil command.
-			return NewStencilAction(log)(cli.NewContext(c.App, flag.NewFlagSet("", flag.ExitOnError), c))
+			if err := NewStencilAction(log)(cli.NewContext(c.App, flag.NewFlagSet("", flag.ExitOnError), c)); err != nil {
+				return err
+			}
+
+			fmt.Println()
+			log.Info("Created module successfully", "module", moduleName)
+			log.Info("- Ensure that 'stencil.yaml' is configured to your liking (e.g., license)")
+			log.Info("- For configuration options provided by stencil-golang, see the docs:")
+			log.Info("  https://github.com/rgst-io/stencil-golang")
+			return nil
 		},
 	}
 }

--- a/cmd/stencil/create_module_test.go
+++ b/cmd/stencil/create_module_test.go
@@ -8,8 +8,10 @@ import (
 	"testing"
 
 	"github.com/urfave/cli/v2"
+	"go.rgst.io/stencil/pkg/configuration"
 	"go.rgst.io/stencil/pkg/slogext"
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/env"
 )
 
 // prepareTestRun sets up the environment for running a stencil command.
@@ -22,13 +24,14 @@ func prepareTestRun(t *testing.T, dir string) {
 	b, err := exec.Command("go", "env", "GOMOD").Output()
 	assert.NilError(t, err)
 	repoRoot := strings.TrimSuffix(strings.TrimSpace(string(b)), "/go.mod")
-	chdir(t, repoRoot)
+
+	env.ChangeWorkingDir(t, repoRoot)
 
 	// Use a temporary directory for the test if one is not provided.
 	if dir == "" {
 		dir = t.TempDir()
 	}
-	chdir(t, dir)
+	env.ChangeWorkingDir(t, dir)
 }
 
 // testRunApp runs the provided cli.App with the provided arguments.
@@ -46,22 +49,6 @@ func testRunCommand(t *testing.T, cmd *cli.Command, dir string, args ...string) 
 	app := cli.NewApp()
 	app.Commands = []*cli.Command{cmd}
 	return app.Run(append([]string{"test", cmd.Name}, args...))
-}
-
-// chdir changes the current working directory to the provided directory
-// and sets up a cleanup function to change it back to the original
-// directory when the test is done. If the cleanup function fails, the
-// test will panic.
-func chdir(t *testing.T, dir string) {
-	origDir, err := os.Getwd()
-	assert.NilError(t, err)
-	assert.NilError(t, os.Chdir(dir))
-	t.Cleanup(func() {
-		if err := os.Chdir(origDir); err != nil {
-			// Failed, not safe to run other tests.
-			panic(err)
-		}
-	})
 }
 
 func TestCanCreateModule(t *testing.T) {
@@ -89,4 +76,30 @@ func TestCreateModuleFailsWhenFilesExist(t *testing.T) {
 
 	err = testRunCommand(t, cmd, tmpDir, "github.com/rgst-io/test-module")
 	assert.ErrorContains(t, err, "directory is not empty, found test-file")
+}
+
+// TestCanCreateNativeExtension ensures that we can render a native
+// extension through stencil-golang. This is technically more of a test
+// of stencil-golang than anything else.
+func TestCanCreateNativeExtension(t *testing.T) {
+	log := slogext.NewTestLogger(t)
+	cmd := NewCreateModuleCommand(log)
+	assert.Assert(t, cmd != nil)
+
+	assert.NilError(t, testRunCommand(t, cmd, "", "--native-extension", "github.com/rgst-io/test-module"))
+
+	// Ensure it created the expected files.
+	expectedFiles := []string{
+		filepath.Join("cmd", "plugin", "plugin.go"),
+		"stencil.yaml",
+	}
+	for _, f := range expectedFiles {
+		_, err := os.Stat(f)
+		assert.NilError(t, err)
+	}
+
+	// Ensure that we have 'plugin' as one of our types.
+	tr, err := configuration.LoadDefaultTemplateRepositoryManifest()
+	assert.NilError(t, err)
+	assert.Assert(t, tr.Type.Contains(configuration.TemplateRepositoryTypeExt))
 }

--- a/cmd/stencil/create_module_test.go
+++ b/cmd/stencil/create_module_test.go
@@ -68,7 +68,7 @@ func TestCanCreateModule(t *testing.T) {
 	log := slogext.NewTestLogger(t)
 	cmd := NewCreateModuleCommand(log)
 	assert.Assert(t, cmd != nil)
-	assert.NilError(t, testRunCommand(t, cmd, "", "test-module"))
+	assert.NilError(t, testRunCommand(t, cmd, "", "github.com/rgst-io/test-module"))
 
 	// Ensure it created the expected files.
 	_, err := os.Stat("stencil.yaml")
@@ -87,6 +87,6 @@ func TestCreateModuleFailsWhenFilesExist(t *testing.T) {
 	assert.NilError(t, err)
 	assert.NilError(t, f.Close())
 
-	err = testRunCommand(t, cmd, tmpDir, "test-module")
+	err = testRunCommand(t, cmd, tmpDir, "github.com/rgst-io/test-module")
 	assert.ErrorContains(t, err, "directory is not empty, found test-file")
 }

--- a/cmd/stencil/describe_test.go
+++ b/cmd/stencil/describe_test.go
@@ -14,6 +14,7 @@ import (
 	"go.rgst.io/stencil/pkg/stencil"
 	"gopkg.in/yaml.v3"
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/env"
 )
 
 func Test_cleanPath(t *testing.T) {
@@ -83,7 +84,7 @@ func Test_cleanPath(t *testing.T) {
 func Test_describeFile_shouldFunction(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	chdir(t, tmpDir)
+	env.ChangeWorkingDir(t, tmpDir)
 
 	lock := &stencil.Lockfile{
 		Modules: []*stencil.LockfileModuleEntry{{

--- a/cmd/stencil/lockfile_prune.go
+++ b/cmd/stencil/lockfile_prune.go
@@ -51,7 +51,7 @@ func NewLockfilePruneCommand(log slogext.Logger) *cli.Command {
 				return errors.Wrap(err, "failed to load lockfile")
 			}
 
-			manifest, err := configuration.NewDefaultManifest()
+			manifest, err := configuration.LoadDefaultManifest()
 			if err != nil {
 				return fmt.Errorf("failed to parse stencil.yaml: %w", err)
 			}

--- a/cmd/stencil/lockfile_prune.go
+++ b/cmd/stencil/lockfile_prune.go
@@ -28,18 +28,21 @@ import (
 // lockfile prune command.
 func NewLockfilePruneCommand(log slogext.Logger) *cli.Command {
 	return &cli.Command{
-		Name:        "prune",
-		Usage:       "Prunes non-existent files from the lockfile",
-		Description: "Prunes any non-existent files from the lockfile (will recreate any file.Once files on next run)",
+		Name:  "prune",
+		Usage: "Prunes non-existent files from the lockfile",
+		Description: "Prunes any non-existent files from the lockfile (will " +
+			"recreate any file.Once files on next run)",
 
 		Flags: []cli.Flag{
 			&cli.StringSliceFlag{
-				Name:  "file",
-				Usage: "If any file options are passed, prune only checks the passed filenames for pruning",
+				Name: "file",
+				Usage: "If any file options are passed, prune only checks the " +
+					"passed filenames for pruning",
 			},
 			&cli.StringSliceFlag{
-				Name:  "module",
-				Usage: "If any module options are passed, prune only checks the passed modulenames for pruning",
+				Name: "module",
+				Usage: "If any module options are passed, prune only checks the " +
+					"passed module names for pruning",
 			},
 		},
 		Action: func(c *cli.Context) error {

--- a/cmd/stencil/stencil.go
+++ b/cmd/stencil/stencil.go
@@ -60,7 +60,7 @@ func NewStencilAction(log slogext.Logger) cli.ActionFunc {
 			log.Debug("Debug logging enabled")
 		}
 
-		manifest, err := configuration.NewDefaultManifest()
+		manifest, err := configuration.LoadDefaultManifest()
 		if err != nil {
 			return fmt.Errorf("failed to parse stencil.yaml: %w", err)
 		}

--- a/cmd/stencil/upgrade.go
+++ b/cmd/stencil/upgrade.go
@@ -39,7 +39,7 @@ func NewUpgradeCommand(log slogext.Logger) *cli.Command {
 				log.Debug("Debug logging enabled")
 			}
 
-			manifest, err := configuration.NewDefaultManifest()
+			manifest, err := configuration.LoadDefaultManifest()
 			if err != nil {
 				return fmt.Errorf("failed to parse stencil.yaml: %w", err)
 			}

--- a/cmd/stencil/upgrade_test.go
+++ b/cmd/stencil/upgrade_test.go
@@ -114,12 +114,7 @@ func TestUpgradeIncludesNewModules(t *testing.T) {
 	assert.NilError(t, err, "failed to write lockfile")
 
 	// Run the upgrade
-	err = testRunCommand(t, cmd, tmpDir)
-	if err != nil {
-		// Right now it errors due to no go.mod, so allow that error to
-		// occur. It doesn't indicate the upgrade failure.
-		assert.ErrorContains(t, err, "failed to run post run command")
-	}
+	assert.NilError(t, testRunCommand(t, cmd, tmpDir), "expected upgrade to not error")
 
 	// Read the lockfile back in and ensure that the module was added.
 	lf, err := stencil.LoadLockfile(tmpDir)

--- a/internal/codegen/values_test.go
+++ b/internal/codegen/values_test.go
@@ -16,19 +16,14 @@ import (
 	"go.rgst.io/stencil/pkg/configuration"
 	"go.rgst.io/stencil/pkg/slogext"
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/env"
 )
 
 func TestValues(t *testing.T) {
 	tmpDir, err := os.MkdirTemp(t.TempDir(), "stencil-values-test")
 	assert.NilError(t, err, "expected os.MkdirTemp() not to fail")
 
-	wd, err := os.Getwd()
-	assert.NilError(t, err, "expected os.Getwd() not to fail")
-
-	// Change directory to the temporary directory, and restore the original
-	// working directory when we're done.
-	os.Chdir(tmpDir)
-	defer func() { os.Chdir(wd) }()
+	env.ChangeWorkingDir(t, tmpDir)
 
 	r, err := gogit.PlainInit(tmpDir, false)
 	assert.NilError(t, err, "expected gogit.PlainInit() not to fail")

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -30,9 +30,21 @@ import (
 // ValidateNameRegexp is the regex used to validate the project's name
 const ValidateNameRegexp = `^[_a-z][_a-z0-9-]*$`
 
-// NewManifest reads a manifest from disk at the
-// specified path, parses it, and returns the output.
+// NewManifest reads a manifest from disk at the specified path, parses
+// it, and returns the output.
+//
+// Deprecated: Use LoadManifest instead.
 func NewManifest(path string) (*Manifest, error) {
+	return LoadManifest(path)
+}
+
+// LoadManifest reads a manifest from disk at the specified path, parses
+// it, and returns the output.
+//
+// In most cases, you should use LoadDefaultManifest instead as it
+// contains the standard locations for a manifest as well as
+// getoutreach/stencil interop.
+func LoadManifest(path string) (*Manifest, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, err
@@ -53,11 +65,19 @@ func NewManifest(path string) (*Manifest, error) {
 
 // NewDefaultManifest returns a parsed project manifest
 // from a set default path on disk.
+//
+// Deprecated: Use LoadDefaultManifest instead.
 func NewDefaultManifest() (*Manifest, error) {
+	return LoadDefaultManifest()
+}
+
+// LoadDefaultManifest returns a parsed project manifest from a set
+// default path on disk.
+func LoadDefaultManifest() (*Manifest, error) {
 	manifestFiles := []string{"stencil.yaml", "service.yaml"}
 	for _, file := range manifestFiles {
 		if _, err := os.Stat(file); err == nil {
-			return NewManifest(file)
+			return LoadManifest(file)
 		}
 	}
 
@@ -105,6 +125,39 @@ type TemplateRepository struct {
 	// will change as the module is resolved on subsequent runs.
 	// Eventually, this will be changed to use the lockfile by default.
 	Version string `yaml:"version,omitempty"`
+}
+
+// LoadTemplateRepositoryManifest reads a template repository manifest
+// from disk and returns it.
+//
+// In most cases, you should use LoadDefaultTemplateRepositoryManifest
+// instead as it contains the standard locations for a manifest.
+func LoadTemplateRepositoryManifest(path string) (*TemplateRepositoryManifest, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var s TemplateRepositoryManifest
+	if err := yaml.NewDecoder(f).Decode(&s); err != nil {
+		return nil, err
+	}
+
+	return &s, nil
+}
+
+// LoadDefaultTemplateRepositoryManifest reads a template repository
+// manifest from disk and returns it, using a standard set of locations.
+func LoadDefaultTemplateRepositoryManifest() (*TemplateRepositoryManifest, error) {
+	manifestFiles := []string{"manifest.yaml"}
+	for _, file := range manifestFiles {
+		if _, err := os.Stat(file); err == nil {
+			return LoadTemplateRepositoryManifest(file)
+		}
+	}
+
+	return nil, fmt.Errorf("no manifest found (searched %v)", manifestFiles)
 }
 
 // TemplateRepositoryManifest is a manifest of a template repository

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -2,11 +2,11 @@ package configuration_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"go.rgst.io/stencil/pkg/configuration"
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/env"
 )
 
 func ExampleValidateName() {
@@ -40,11 +40,7 @@ func ExampleNewManifest() {
 }
 
 func TestShouldSupportServiceYaml(t *testing.T) {
-	// Change into test directory
-	curDir, err := os.Getwd()
-	assert.NilError(t, err)
-	defer os.Chdir(curDir)
-	assert.NilError(t, os.Chdir("testdata/interop/service-if-not-found"))
+	env.ChangeWorkingDir(t, "testdata/interop/service-if-not-found")
 
 	sm, err := configuration.LoadDefaultManifest()
 	assert.NilError(t, err)
@@ -53,14 +49,19 @@ func TestShouldSupportServiceYaml(t *testing.T) {
 }
 
 func TestShouldUseStencilOverServiceYaml(t *testing.T) {
-	// Change into test directory
-	curDir, err := os.Getwd()
-	assert.NilError(t, err)
-	defer os.Chdir(curDir)
-	assert.NilError(t, os.Chdir("testdata/interop/stencil-over-service"))
+	env.ChangeWorkingDir(t, "testdata/interop/stencil-over-service")
 
 	sm, err := configuration.LoadDefaultManifest()
 	assert.NilError(t, err)
 
 	assert.Equal(t, sm.Name, "stencil")
+}
+
+func TestLoadDefaultTemplateRepositoryManifestShouldLoad(t *testing.T) {
+	env.ChangeWorkingDir(t, "testdata/tr-default")
+
+	sm, err := configuration.LoadDefaultTemplateRepositoryManifest()
+	assert.NilError(t, err)
+
+	assert.Equal(t, sm.Name, "github.com/rgst-io/test-module")
 }

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -46,7 +46,7 @@ func TestShouldSupportServiceYaml(t *testing.T) {
 	defer os.Chdir(curDir)
 	assert.NilError(t, os.Chdir("testdata/interop/service-if-not-found"))
 
-	sm, err := configuration.NewDefaultManifest()
+	sm, err := configuration.LoadDefaultManifest()
 	assert.NilError(t, err)
 
 	assert.Equal(t, sm.Name, "service")
@@ -59,7 +59,7 @@ func TestShouldUseStencilOverServiceYaml(t *testing.T) {
 	defer os.Chdir(curDir)
 	assert.NilError(t, os.Chdir("testdata/interop/stencil-over-service"))
 
-	sm, err := configuration.NewDefaultManifest()
+	sm, err := configuration.LoadDefaultManifest()
 	assert.NilError(t, err)
 
 	assert.Equal(t, sm.Name, "stencil")

--- a/pkg/configuration/testdata/tr-default/manifest.yaml
+++ b/pkg/configuration/testdata/tr-default/manifest.yaml
@@ -1,0 +1,1 @@
+name: github.com/rgst-io/test-module

--- a/pkg/configuration/type_test.go
+++ b/pkg/configuration/type_test.go
@@ -24,20 +24,28 @@ func TestTemplateRepositoryType(t *testing.T) {
 			DoesNotContain: []configuration.TemplateRepositoryType{configuration.TemplateRepositoryTypeExt},
 		},
 		{
-			Name:           "templates",
+			Name:           "string templates",
 			In:             "templates",
 			Contains:       []configuration.TemplateRepositoryType{configuration.TemplateRepositoryTypeTemplates},
 			DoesNotContain: []configuration.TemplateRepositoryType{configuration.TemplateRepositoryTypeExt},
 		},
 		{
-			Name:           "extension",
+			Name:           "string extension",
 			In:             "extension",
 			Contains:       []configuration.TemplateRepositoryType{configuration.TemplateRepositoryTypeExt},
 			DoesNotContain: []configuration.TemplateRepositoryType{configuration.TemplateRepositoryTypeTemplates},
 		},
 		{
-			Name: "both",
+			Name: "legacy csv both",
 			In:   "extension,templates",
+			Contains: []configuration.TemplateRepositoryType{
+				configuration.TemplateRepositoryTypeExt,
+				configuration.TemplateRepositoryTypeTemplates,
+			},
+		},
+		{
+			Name: "slice both",
+			In:   "- extension\n- templates",
 			Contains: []configuration.TemplateRepositoryType{
 				configuration.TemplateRepositoryTypeExt,
 				configuration.TemplateRepositoryTypeTemplates,
@@ -45,26 +53,22 @@ func TestTemplateRepositoryType(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		test := test // for the parallel closure
+	for i := range tests {
+		test := &tests[i]
+
 		t.Run(test.Name, func(t *testing.T) {
-			//t.Parallel()
+			t.Parallel()
+
 			var ts configuration.TemplateRepositoryTypes
-			err := yaml.Unmarshal([]byte(test.In), &ts)
-			assert.NilError(t, err)
+			assert.NilError(t, yaml.Unmarshal([]byte(test.In), &ts))
+
 			for _, typ := range test.Contains {
 				assert.Assert(t, ts.Contains(typ))
 			}
+
 			for _, typ := range test.DoesNotContain {
 				assert.Assert(t, !ts.Contains(typ))
 			}
-			// rountrip marshal
-			b, err := ts.MarshalYAML()
-			assert.NilError(t, err)
-			s, isString := b.(string)
-
-			assert.Equal(t, true, isString)
-			assert.Equal(t, test.In, s, "roundtrip marshal failed")
 		})
 	}
 }

--- a/schemas/manifest.jsonschema.json
+++ b/schemas/manifest.jsonschema.json
@@ -99,9 +99,8 @@
 			"description": "TemplateRepositoryManifest is a manifest of a template repository"
 		},
 		"TemplateRepositoryTypes": {
-			"properties": {},
-			"additionalProperties": false,
-			"type": "object",
+			"items": { "type": "string" },
+			"type": "array",
 			"description": "TemplateRepositoryTypes specifies what type of a stencil repository the current one is."
 		}
 	}


### PR DESCRIPTION
Adds support for generating modules with a `manifest.yaml` as well as
populating `service.yaml` using `rgst-io/stencil-golang` in library
mode, unless specified to create a native extension.

stencil-golang in library mode has full CI, and is used mainly only for
releasing. Eventually, the release logic will be moved out and turned
into some framework (or use some other one) since it is a bit awkward to
depend on that for non-Go repositories.
