### PR TITLE
chore: remove getoutreach references in tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,7 +17,7 @@
 	"gopls": {
 		"build.buildFlags": ["-tags=or_dev"]
 	},
-	"cSpell.words": ["codegen", "getoutreach", "gogit", "templating", "worktree"],
+	"cSpell.words": ["codegen", "gogit", "templating", "worktree"],
 
 	// Schema support OOTB.
 	"yaml.schemas": {

--- a/docs/reference/template-module.md
+++ b/docs/reference/template-module.md
@@ -95,19 +95,22 @@ items:
 
 #### Aliasing an argument with `from`
 
-Aliasing an argument allows you to reference another argument from within the module. For example, if you have an argument called `description` and you want to alias it to another argument called from the module `github.com/getoutreach/stencil-base`, you can do so like so:
+Aliasing an argument allows you to reference another argument from
+within the module. For example, if you have an argument called
+`description` and you want to alias it to another argument called from
+the module `github.com/rgst-io/stencil-golang`, you can do so like so
 
 ```yaml
 # your module
 arguments:
-	description:
-		from: github.com/getoutreach/stencil-base
+  description:
+    from: github.com/rgst-io/stencil-golang
 
-# github.com/getoutreach/stencil-base
+# github.com/rgst-io/stencil-golang
 arguments:
-	description:
-		schema:
-			type: string
+  description:
+    schema:
+      type: string
 ```
 
 There's a few limitations with aliasing arguments:
@@ -159,7 +162,7 @@ func TestGoMod(t \*testing.T) {
 	st := stenciltest.New(t, "go.mod.tpl")
 
 	// Define the arguments to pass to stencil
-	st.Args(map[string]interface{}{"org": "getoutreach"})
+	st.Args(map[string]interface{}{"org": "rgst-io"})
 
 	// Run the test, persisting the snapshot to disk if it changed.
 	// Default is set to false.

--- a/internal/cmd/stencil/stencil_test.go
+++ b/internal/cmd/stencil/stencil_test.go
@@ -87,7 +87,7 @@ func TestResolveShouldNotUpgradeOtherModulesWhenUpgradingOne(t *testing.T) {
 			},
 			{
 				// TODO(jaredallard): We need some more test live repos.
-				Name: "github.com/getoutreach/devbase",
+				Name: "github.com/rgst-io/stencil-module",
 			},
 		},
 	}, false)
@@ -99,10 +99,10 @@ func TestResolveShouldNotUpgradeOtherModulesWhenUpgradingOne(t *testing.T) {
 				Tag:    "v0.4.0",
 			},
 		}, {
-			Name: "github.com/getoutreach/devbase",
+			Name: "github.com/rgst-io/stencil-module",
 			Version: &resolver.Version{
-				Commit: "850cae0d50691772bd56267d2056b9dd1b246176",
-				Tag:    "v2.27.1",
+				Commit: "8a953c803b4762fbe90da806f39ad7af404aca0a",
+				Tag:    "v0.1.0",
 			},
 		}},
 	}
@@ -119,7 +119,7 @@ func TestResolveShouldNotUpgradeOtherModulesWhenUpgradingOne(t *testing.T) {
 	})
 
 	// other module shouldn't be changed
-	assert.DeepEqual(t, modsHM["github.com/getoutreach/devbase"].Version, s.lock.Modules[1].Version)
+	assert.DeepEqual(t, modsHM["github.com/rgst-io/stencil-module"].Version, s.lock.Modules[1].Version)
 }
 
 // TestResolveModulesShouldUpdateReplacements ensures that stencil will
@@ -162,17 +162,16 @@ func TestResolveModulesShouldAllowAdds(t *testing.T) {
 				Name:    "github.com/rgst-io/stencil-golang",
 				Version: "v0.5.0", // 3c3213721335c53fd78f4fede1b3704801616615
 			}, {
-				// TODO(jaredallard): We need some more test live repos.
-				Name: "github.com/getoutreach/devbase",
+				Name: "github.com/rgst-io/stencil-module",
 			},
 		},
 	}, false)
 	s.lock = &stencil.Lockfile{
 		Modules: []*stencil.LockfileModuleEntry{{
-			Name: "github.com/getoutreach/devbase",
+			Name: "github.com/rgst-io/stencil-module",
 			Version: &resolver.Version{
-				Commit: "850cae0d50691772bd56267d2056b9dd1b246176",
-				Tag:    "v2.27.1",
+				Commit: "8a953c803b4762fbe90da806f39ad7af404aca0a",
+				Tag:    "v0.1.0",
 			},
 		}},
 	}

--- a/internal/modules/module_test.go
+++ b/internal/modules/module_test.go
@@ -23,7 +23,7 @@ func newLogger(t *testing.T) slogext.Logger {
 func TestCanFetchModule(t *testing.T) {
 	ctx := context.Background()
 	m, err := modules.New(ctx, "", modules.NewModuleOpts{
-		ImportPath: "github.com/getoutreach/stencil-base", Version: &resolver.Version{Branch: "main"},
+		ImportPath: "github.com/rgst-io/stencil-module", Version: &resolver.Version{Branch: "main"},
 	})
 	assert.NilError(t, err, "failed to call New()")
 	assert.Assert(t, m.Manifest.Type.Contains(configuration.TemplateRepositoryTypeTemplates), "failed to validate returned manifest")
@@ -40,18 +40,18 @@ func TestReplacementLocalModule(t *testing.T) {
 		Name: "testing-project",
 		Modules: []*configuration.TemplateRepository{
 			{
-				Name: "github.com/getoutreach/stencil-base",
+				Name: "github.com/rgst-io/stencil-module",
 			},
 		},
 		Replacements: map[string]string{
-			"github.com/getoutreach/stencil-base": "file://testdata",
+			"github.com/rgst-io/stencil-module": "file://testdata",
 		},
 	}
 
 	mods, err := modules.FetchModules(context.Background(), &modules.ModuleResolveOptions{Manifest: sm, Log: newLogger(t)})
 	assert.NilError(t, err, "expected GetModulesForProject() to not error")
 	assert.Equal(t, len(mods), 1, "expected exactly one module to be returned")
-	assert.Equal(t, mods[0].URI, sm.Replacements["github.com/getoutreach/stencil-base"],
+	assert.Equal(t, mods[0].URI, sm.Replacements["github.com/rgst-io/stencil-module"],
 		"expected module to use replacement URI")
 }
 
@@ -62,7 +62,7 @@ func TestCanGetLatestVersion(t *testing.T) {
 			Name: "testing-project",
 			Modules: []*configuration.TemplateRepository{
 				{
-					Name: "github.com/getoutreach/stencil-base",
+					Name: "github.com/rgst-io/stencil-module",
 				},
 			},
 		},
@@ -104,8 +104,6 @@ func TestHandleMultipleConstraints(t *testing.T) {
 		}
 	}
 
-	// should resolve to v0.3.2 because testdata wants latest patch of 0.3.0, while we want =<0.5.0
-	// which is the latest patch of 0.3.0
 	assert.DeepEqual(t,
 		mods[index].Version,
 		&resolver.Version{Tag: "v0.3.2", Commit: "91797167d0e48ae4c9640c0acbd7447eb9e1e5e4"},
@@ -180,7 +178,7 @@ func TestCanUseBranch(t *testing.T) {
 			Name: "testing-project",
 			Modules: []*configuration.TemplateRepository{
 				{
-					Name:    "github.com/getoutreach/stencil-base",
+					Name:    "github.com/rgst-io/stencil-module",
 					Version: "main",
 				},
 			},
@@ -191,7 +189,7 @@ func TestCanUseBranch(t *testing.T) {
 
 	var mod *modules.Module
 	for _, m := range mods {
-		if m.Name == "github.com/getoutreach/stencil-base" {
+		if m.Name == "github.com/rgst-io/stencil-module" {
 			mod = m
 			break
 		}
@@ -211,7 +209,7 @@ func TestBranchAlwaysUsedOverDependency(t *testing.T) {
 		Name: "test",
 		Modules: []*configuration.TemplateRepository{
 			{
-				Name:    "github.com/getoutreach/stencil-base",
+				Name:    "github.com/rgst-io/stencil-module",
 				Version: ">=v0.0.0",
 			},
 		},
@@ -227,7 +225,7 @@ func TestBranchAlwaysUsedOverDependency(t *testing.T) {
 			Name: "testing-project",
 			Modules: []*configuration.TemplateRepository{
 				{
-					Name:    "github.com/getoutreach/stencil-base",
+					Name:    "github.com/rgst-io/stencil-module",
 					Version: "main",
 				},
 				{
@@ -241,7 +239,7 @@ func TestBranchAlwaysUsedOverDependency(t *testing.T) {
 
 	var mod *modules.Module
 	for _, m := range mods {
-		if m.Name == "github.com/getoutreach/stencil-base" {
+		if m.Name == "github.com/rgst-io/stencil-module" {
 			mod = m
 			break
 		}
@@ -304,28 +302,28 @@ func TestShouldResolveInMemoryModule(t *testing.T) {
 	assert.Equal(t, mod.Name, m.Name, "expected module to match")
 }
 
-func TestShouldErrorOnTwoDifferentChannels(t *testing.T) {
+func TestShouldErrorOnTwoDifferentBranches(t *testing.T) {
 	ctx := context.Background()
 	_, err := modules.FetchModules(ctx, &modules.ModuleResolveOptions{
 		Manifest: &configuration.Manifest{
 			Name: "testing-project",
 			Modules: []*configuration.TemplateRepository{
 				{
-					Name:    "github.com/getoutreach/stencil-base",
-					Version: "rc",
+					Name:    "github.com/rgst-io/stencil-module",
+					Version: "main",
 				},
 				{
-					Name:    "github.com/getoutreach/stencil-base",
-					Version: "unstable",
+					Name:    "github.com/rgst-io/stencil-module",
+					Version: "rc",
 				},
 			},
 		},
 		Log: newLogger(t),
 	})
 	assert.ErrorContains(t, err,
-		"failed to resolve module 'github.com/getoutreach/stencil-base' with constraints\n"+
-			"└─ testing-project (top-level) wants branch rc\n"+
-			"  └─ testing-project (top-level) wants branch unstable\n",
+		"failed to resolve module 'github.com/rgst-io/stencil-module' with constraints\n"+
+			"└─ testing-project (top-level) wants branch main\n"+
+			"  └─ testing-project (top-level) wants branch rc\n",
 		"expected GetModulesForProject() to error")
 }
 

--- a/internal/modules/nativeext/caller.go
+++ b/internal/modules/nativeext/caller.go
@@ -26,7 +26,7 @@ type ExtensionCaller struct {
 }
 
 // Call returns a function based on its path, e.g. test.callFunction
-func (ec *ExtensionCaller) Call(args ...interface{}) (interface{}, error) {
+func (ec *ExtensionCaller) Call(args ...interface{}) (any, error) {
 	if len(args) == 0 {
 		return nil, fmt.Errorf("expected at least 1 arg")
 	}

--- a/internal/modules/nativeext/nativeext_test.go
+++ b/internal/modules/nativeext/nativeext_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/jaredallard/vcs/resolver"
 	"go.rgst.io/stencil/internal/modules/nativeext"
 	"go.rgst.io/stencil/pkg/slogext"
@@ -37,21 +36,18 @@ func TestCanImportNativeExtension(t *testing.T) {
 	ext := nativeext.NewHost(slogext.NewTestLogger(t))
 	defer ext.Close()
 
-	ver, err := resolver.NewResolver().Resolve(ctx, "https://github.com/getoutreach/stencil-golang", &resolver.Criteria{
-		Constraint: "=1.23.3",
+	ver, err := resolver.NewResolver().Resolve(ctx, "https://github.com/rgst-io/stencil-golang", &resolver.Criteria{
+		Constraint: "=1.1.0",
 	})
 	assert.NilError(t, err, "failed to resolve version")
 
-	err = ext.RegisterExtension(ctx, "https://github.com/getoutreach/stencil-golang", "github.com/getoutreach/stencil-golang", ver)
+	err = ext.RegisterExtension(ctx, "https://github.com/rgst-io/stencil-golang", "github.com/rgst-io/stencil-golang", ver)
 	assert.NilError(t, err, "failed to register extension")
 
 	caller, err := ext.GetExtensionCaller(ctx)
 	assert.NilError(t, err, "failed to get extension caller")
 
-	resp, err := caller.Call("github.com/getoutreach/stencil-golang.ParseGoMod", "go.mod", "module test\n\ngo 1.19")
+	resp, err := caller.Call("github.com/rgst-io/stencil-golang.GetLicense", "GPL-3.0")
 	assert.NilError(t, err, "failed to call extension")
-
-	moduleMap := resp.(map[string]any)["Module"].(map[string]any)
-	spew.Dump(moduleMap)
-	assert.Equal(t, moduleMap["Syntax"].(map[string]any)["Token"].([]any)[1], "test", "failed to parse go.mod")
+	assert.Assert(t, resp != "")
 }

--- a/internal/modules/testdata/manifest.yaml
+++ b/internal/modules/testdata/manifest.yaml
@@ -1,1 +1,1 @@
-name: github.com/getoutreach/stencil-base
+name: github.com/rgst-io/stencil-module


### PR DESCRIPTION
Removes most of the leftover `getoutreach` references left in test and other places.

Related to #1 