### PR TITLE
fix: Cross-module calls should execute in the context of the callee

### DIFF
--- a/docs/funcs/module.Call.md
+++ b/docs/funcs/module.Call.md
@@ -17,7 +17,7 @@ The template that is called must return a value using the `return`
 template function, which is only available in this context.
 
 In addition, all of the file, stencil and other functions are in the
-context of the parent template, not the template being called.
+context of the owning template, not the template calling the function.
 
 `.` in a template function acts the same way as it does for [TplStencil.ApplyTemplate](#TplStencil.ApplyTemplate) (`stencil.ApplyTemplate`). Meaning, it points to [Values](#Values). The caller passed data is accessible on `.Data`.
 

--- a/internal/codegen/shared_state.go
+++ b/internal/codegen/shared_state.go
@@ -56,6 +56,12 @@ type global struct {
 	Value any
 }
 
+// exportedFunction stores data about a function that has been exported with
+// module.Export for later retrieval/usage at module.Call-time.
+type exportedFunction struct {
+	Template *Template
+}
+
 // sharedState stores data that is injected by templates and shared
 // between them.
 //
@@ -64,7 +70,7 @@ type global struct {
 type sharedState struct {
 	// functions is a map of modules to templates that have been exported
 	// through [TplModule].
-	Functions   *xsync.MapOf[string, struct{}]
+	Functions   *xsync.MapOf[string, exportedFunction]
 	Globals     *xsync.MapOf[string, global]
 	ModuleHooks *xsync.MapOf[string, moduleHook]
 }
@@ -73,7 +79,7 @@ type sharedState struct {
 // sharedData type.
 func newSharedState() *sharedState {
 	return &sharedState{
-		Functions:   xsync.NewMapOf[string, struct{}](),
+		Functions:   xsync.NewMapOf[string, exportedFunction](),
 		ModuleHooks: xsync.NewMapOf[string, moduleHook](),
 		Globals:     xsync.NewMapOf[string, global](),
 	}

--- a/internal/codegen/tpl_module.go
+++ b/internal/codegen/tpl_module.go
@@ -101,7 +101,7 @@ func (tm *TplModule) Export(name string) (string, error) {
 // template function, which is only available in this context.
 //
 // In addition, all of the file, stencil and other functions are in the
-// context of the parent template, not the template being called.
+// context of the owning template, not the template calling the function.
 //
 // `.` in a template function acts the same way as it does for
 // [TplStencil.ApplyTemplate] (`stencil.ApplyTemplate`). Meaning, it

--- a/internal/codegen/tpl_module_test.go
+++ b/internal/codegen/tpl_module_test.go
@@ -81,26 +81,26 @@ func TestTplModule_Tpl(t *testing.T) {
 			want:            "hello",
 		},
 		{
-			name: "should use data from caller",
-			functionTemplate: `{{- define "HelloWorld" -}}
-		{{ return (file.Path) }}
-		{{- end -}}
-		{{- module.Export "HelloWorld" -}}`,
-			callingTemplate: `{{ module.Call "function.HelloWorld" }}`,
-			// This is "caller" because the path should be from the template
-			// we are calling from. Otherwise, this would be "function".
-			want: "caller",
-		},
-		{
 			name:        "should break on duplicate export",
 			renderStage: renderStageFinal,
 			functionTemplate: `{{- define "HelloWorld" -}}
-{{ return (fromYaml "hello: world") }}
-{{- end -}}
-{{- module.Export "HelloWorld" -}}
-{{- module.Export "HelloWorld" -}}`,
+		{{ return (fromYaml "hello: world") }}
+		{{- end -}}
+		{{- module.Export "HelloWorld" -}}
+		{{- module.Export "HelloWorld" -}}`,
 			callingTemplate:     ``,
 			wantFuncErrContains: "already exported",
+		},
+		{
+			name: "use context from module being called",
+			functionTemplate: `{{- stencil.SetGlobal "a" "func" -}}
+		{{- define "HelloWorld" -}}
+		{{ return (stencil.GetGlobal "a") }}
+		{{- end -}}
+		{{- module.Export "HelloWorld" -}}`,
+			callingTemplate: `{{- stencil.SetGlobal "a" "caller" -}}
+		{{ module.Call "function.HelloWorld" }}`,
+			want: "func",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
The original design was to use the context of the caller in the functions being called, but after we tried to implement a function call this way realized that it was inverting ownership from usual function ownership.  The idea was to be able to use helper functions in the context of the caller, but the reality is that you want to pass in any needed context to the exported function, just like in standard programming.  This way the function owner can have "private" state/context inside the module that the function exposes a part of, per standard modules in general software engineering.