### PR TITLE
fix(modules): display more information on repo not found

### DIFF
--- a/internal/modules/module_test.go
+++ b/internal/modules/module_test.go
@@ -357,5 +357,5 @@ func TestShouldErrorOnNonExistentRepo(t *testing.T) {
 		Log: newLogger(t),
 	})
 	//nolint:lll // Why: Error message is long.
-	assert.ErrorContains(t, err, "failed to resolve module 'github.com/rgst-io/i-am-not-a-real-repo': failed to get remote branches: exec failed (exit status 128): remote: Repository not found.\nfatal: repository 'https://github.com/rgst-io/i-am-not-a-real-repo/' not found\n", "expected GetModulesForProject() to error")
+	assert.Error(t, err, "failed to resolve module 'github.com/rgst-io/i-am-not-a-real-repo': failed to get remote branches: exec failed (exit status 128): remote: Repository not found.\nfatal: repository 'https://github.com/rgst-io/i-am-not-a-real-repo/' not found\n\n\nThis error could be due to invalid credentials. Ensure your git configuration is correct.", "expected GetModulesForProject() to error")
 }

--- a/internal/modules/modules.go
+++ b/internal/modules/modules.go
@@ -146,6 +146,23 @@ func resolutionError(err error, importPath string, history []history) error {
 	if resolverHistory != "" {
 		err = fmt.Errorf("%w\n\nConstraints:\n%s", err, resolverHistory)
 	}
+
+	// If we failed to get the remote branches, this is probably due to
+	// credentials than the more common message (not found) would suggest.
+	// So, attempt to be helpful by suggesting they check their git
+	// configuration.
+	//
+	// Note that "git" is hardcoded here because this module resolver
+	// still uses git for credentials as opposed to the
+	// [github.com/jaredallard/vcs/token] library used elsewhere. This
+	// will be adjusted in the future.
+	if strings.Contains(err.Error(), "failed to get remote branches") {
+		helpMessage := []string{
+			"This error could be due to invalid credentials.",
+			"Ensure your git configuration is correct.",
+		}
+		err = fmt.Errorf("%w\n\n%s", err, strings.Join(helpMessage, " "))
+	}
 	return err
 }
 


### PR DESCRIPTION
Adds more details when the error is due to remotes being unable to be
found. This could be a credentials issue, so it's worth highlighting it
in the error message.

As part of this, I was reminded that we use `git` only for credentials
here, which should probably be switched to the token library in the
future. We don't do this right now since its hard to configure host git
on the fly to use the system-wide token, but it's worth considering to
unify token sources in the future.
