### PR TITLE
fix(nativeext):  text file busy

### DIFF
--- a/internal/modules/nativeext/nativeext.go
+++ b/internal/modules/nativeext/nativeext.go
@@ -231,7 +231,7 @@ func (h *Host) downloadFromRemote(ctx context.Context, source, name string, vers
 	syscall.ForkLock.RLock()
 	defer syscall.ForkLock.RUnlock()
 
-	f, err := os.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o755)
+	f, err := os.OpenFile(dlPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o755)
 	if err != nil {
 		return "", fmt.Errorf("failed to create file: %w", err)
 	}


### PR DESCRIPTION
There's a potential race when writing to a file and attempting to
execute it immediately after on Linux. While this may not entirely be
the cause, it seems reasonable enough to attempt the workaround of
locking `syscall.ForkLock`.
