### PR TITLE
fix(pkg/configuration)!: remove New*Manifest functions

### DIFF
--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -30,14 +30,6 @@ import (
 // ValidateNameRegexp is the regex used to validate the project's name
 const ValidateNameRegexp = `^[_a-z][_a-z0-9-]*$`
 
-// NewManifest reads a manifest from disk at the specified path, parses
-// it, and returns the output.
-//
-// Deprecated: Use LoadManifest instead.
-func NewManifest(path string) (*Manifest, error) {
-	return LoadManifest(path)
-}
-
 // LoadManifest reads a manifest from disk at the specified path, parses
 // it, and returns the output.
 //
@@ -61,14 +53,6 @@ func LoadManifest(path string) (*Manifest, error) {
 	}
 
 	return s, nil
-}
-
-// NewDefaultManifest returns a parsed project manifest
-// from a set default path on disk.
-//
-// Deprecated: Use LoadDefaultManifest instead.
-func NewDefaultManifest() (*Manifest, error) {
-	return LoadDefaultManifest()
 }
 
 // LoadDefaultManifest returns a parsed project manifest from a set

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -23,8 +23,8 @@ func ExampleValidateName() {
 	// success: false
 }
 
-func ExampleNewManifest() {
-	sm, err := configuration.NewManifest("testdata/stencil.yaml")
+func ExampleLoadManifest() {
+	sm, err := configuration.LoadManifest("testdata/stencil.yaml")
 	if err != nil {
 		// handle the error
 		fmt.Println("error:", err)


### PR DESCRIPTION
Removes the deprecated `NewManifest` and `NewDefaultManifest` functions.
These were replaced by their `Load` counterparts.
