### PR TITLE
fix(nativeext): ensure cache dir exists

### DIFF
--- a/internal/modules/nativeext/nativeext.go
+++ b/internal/modules/nativeext/nativeext.go
@@ -82,6 +82,10 @@ func NewHost(log slogext.Logger) (*Host, error) {
 		return nil, err
 	}
 
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		log.WithError(err).Warn("failed to create native extension cache directory, native extensions may fail to download/run")
+	}
+
 	return &Host{
 		mu:         lockedfile.MutexAt(filepath.Join(cacheDir, "cache.lock")),
 		r:          resolver.NewResolver(),


### PR DESCRIPTION
Ensures that the cache directory exists before creating the extension
host. This fixes a case where locking could fail due to the cache
directory not existing yet.
