### PR TITLE
fix(release): properly set versions after import path change

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,11 +12,11 @@ builds:
       - -s
       - -w
       ## <<Stencil::Block(stencilLdflags)>>
-      - -X go.rgst.io/stencil/internal/version.version={{.Version}}
-      - -X go.rgst.io/stencil/internal/version.commit={{.Commit}}
-      - -X go.rgst.io/stencil/internal/version.date={{ .CommitDate }}
-      - -X go.rgst.io/stencil/internal/version.builtBy=goreleaser
-      - -X go.rgst.io/stencil/internal/version.treeState={{ if .IsGitDirty }}dirty{{ else }}clean{{ end }}
+      - -X go.rgst.io/stencil/v2/internal/version.version={{.Version}}
+      - -X go.rgst.io/stencil/v2/internal/version.commit={{.Commit}}
+      - -X go.rgst.io/stencil/v2/internal/version.date={{ .CommitDate }}
+      - -X go.rgst.io/stencil/v2/internal/version.builtBy=goreleaser
+      - -X go.rgst.io/stencil/v2/internal/version.treeState={{ if .IsGitDirty }}dirty{{ else }}clean{{ end }}
       ## <</Stencil::Block>>
     env:
       - CGO_ENABLED=0

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -103,7 +103,7 @@ type TemplateRepository struct {
 	//
 	// Version can also be a constraint as supported by the underlying
 	// resolver:
-	// https://pkg.go.dev/go.rgst.io/stencil/internal/modules/resolver
+	// https://pkg.go.dev/go.rgst.io/stencil/v2/internal/modules/resolver
 	//
 	// But note that constraints are currently not locked so the version
 	// will change as the module is resolved on subsequent runs.

--- a/schemas/manifest.jsonschema.json
+++ b/schemas/manifest.jsonschema.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://json-schema.org/draft-07/schema#",
-	"$id": "https://go.rgst.io/stencil/pkg/configuration/template-repository-manifest",
+	"$id": "https://go.rgst.io/stencil/v2/pkg/configuration/template-repository-manifest",
 	"$ref": "#/$defs/TemplateRepositoryManifest",
 	"$defs": {
 		"Argument": {
@@ -65,7 +65,7 @@
 				},
 				"version": {
 					"type": "string",
-					"description": "Version is a semantic version or branch of the template repository\nthat should be downloaded if not set then the latest version is used.\n\nVersion can also be a constraint as supported by the underlying\nresolver:\nhttps://pkg.go.dev/go.rgst.io/stencil/internal/modules/resolver\n\nBut note that constraints are currently not locked so the version\nwill change as the module is resolved on subsequent runs.\nEventually, this will be changed to use the lockfile by default."
+					"description": "Version is a semantic version or branch of the template repository\nthat should be downloaded if not set then the latest version is used.\n\nVersion can also be a constraint as supported by the underlying\nresolver:\nhttps://pkg.go.dev/go.rgst.io/stencil/v2/internal/modules/resolver\n\nBut note that constraints are currently not locked so the version\nwill change as the module is resolved on subsequent runs.\nEventually, this will be changed to use the lockfile by default."
 				}
 			},
 			"additionalProperties": false,

--- a/schemas/stencil.jsonschema.json
+++ b/schemas/stencil.jsonschema.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://json-schema.org/draft-07/schema#",
-	"$id": "https://go.rgst.io/stencil/pkg/configuration/manifest",
+	"$id": "https://go.rgst.io/stencil/v2/pkg/configuration/manifest",
 	"$ref": "#/$defs/Manifest",
 	"$defs": {
 		"Manifest": {
@@ -42,7 +42,7 @@
 				},
 				"version": {
 					"type": "string",
-					"description": "Version is a semantic version or branch of the template repository\nthat should be downloaded if not set then the latest version is used.\n\nVersion can also be a constraint as supported by the underlying\nresolver:\nhttps://pkg.go.dev/go.rgst.io/stencil/internal/modules/resolver\n\nBut note that constraints are currently not locked so the version\nwill change as the module is resolved on subsequent runs.\nEventually, this will be changed to use the lockfile by default."
+					"description": "Version is a semantic version or branch of the template repository\nthat should be downloaded if not set then the latest version is used.\n\nVersion can also be a constraint as supported by the underlying\nresolver:\nhttps://pkg.go.dev/go.rgst.io/stencil/v2/internal/modules/resolver\n\nBut note that constraints are currently not locked so the version\nwill change as the module is resolved on subsequent runs.\nEventually, this will be changed to use the lockfile by default."
 				}
 			},
 			"additionalProperties": false,

--- a/tools/schemagen/go.mod
+++ b/tools/schemagen/go.mod
@@ -1,12 +1,12 @@
-module go.rgst.io/stencil/tools/schemagen
+module go.rgst.io/stencil/v2/tools/schemagen
 
 go 1.23.4
 
-replace go.rgst.io/stencil => ../..
+replace go.rgst.io/stencil/v2 => ../..
 
 require (
 	github.com/invopop/jsonschema v0.13.0
-	go.rgst.io/stencil v0.0.0-00010101000000-000000000000
+	go.rgst.io/stencil/v2 v2.0.0-00010101000000-000000000000
 )
 
 require (

--- a/tools/schemagen/go.sum
+++ b/tools/schemagen/go.sum
@@ -26,6 +26,7 @@ github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/f
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
 github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/tools/schemagen/schemagen.go
+++ b/tools/schemagen/schemagen.go
@@ -22,7 +22,7 @@ import (
 	"path/filepath"
 
 	"github.com/invopop/jsonschema"
-	"go.rgst.io/stencil/pkg/configuration"
+	"go.rgst.io/stencil/v2/pkg/configuration"
 )
 
 type schema struct {
@@ -52,7 +52,7 @@ func main() {
 		r.FieldNameTag = "yaml"
 
 		// Add comments to the schema.
-		if err := r.AddGoComments("go.rgst.io/stencil", "pkg/configuration"); err != nil {
+		if err := r.AddGoComments("go.rgst.io/stencil/v2", "pkg/configuration"); err != nil {
 			fmt.Printf("error adding comments for %s: %v\n", s.FileName, err)
 			os.Exit(1)
 		}


### PR DESCRIPTION
Once we changed to `v2`, we needed to also update the goreleaser
configuration to reflect the new import path, which was not done.
