### PR TITLE
chore: fix incorrect docs example, switch to ubi toolchain

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -2,15 +2,15 @@
 # Default versions of tools, to update these, set [tools.override]
 [tools]
 bun = "latest"
-git-cliff = "latest"
 golang = "1.23.4"
-golangci-lint = "1.63.4"
-goreleaser = "latest"
 "go:gotest.tools/gotestsum" = "v1.12.0"
 "go:golang.org/x/tools/cmd/goimports" = "latest"
 "go:mvdan.cc/sh/v3/cmd/shfmt" = "latest"
 "go:github.com/thenativeweb/get-next-version" = "latest"
 "go:sigs.k8s.io/mdtoc" = "latest"
+"ubi:golangci/golangci-lint" = "1.63.4"
+"ubi:goreleaser/goreleaser" = "2"
+"ubi:orhun/git-cliff" = "2"
 
 [tasks.build]
 description = "Build a binary for the current platform/architecture"

--- a/docs/funcs/stencil.AddToModuleHook.md
+++ b/docs/funcs/stencil.AddToModuleHook.md
@@ -14,5 +14,5 @@ at how the owning module uses it for now.
 
 ```go
 {{- /* This writes to a module hook */}}
-{{- stencil.AddToModuleHook "github.com/myorg/repo" "myModuleHook" (list "myData") }}
+{{- stencil.AddToModuleHook "github.com/myorg/repo" "myModuleHook" "myData" }}
 ```

--- a/internal/codegen/tpl_stencil.go
+++ b/internal/codegen/tpl_stencil.go
@@ -134,7 +134,7 @@ func (s *TplStencil) GetGlobal(name string) any {
 // to look at how the owning module uses it for now.
 //
 //	{{- /* This writes to a module hook */}}
-//	{{- stencil.AddToModuleHook "github.com/myorg/repo" "myModuleHook" (list "myData") }}
+//	{{- stencil.AddToModuleHook "github.com/myorg/repo" "myModuleHook" "myData" }}
 func (s *TplStencil) AddToModuleHook(module, name string, data ...any) (out string, err error) {
 	// Attempt to read the destined module's manifest for extra features.
 	var mcfg *configuration.TemplateRepositoryManifest


### PR DESCRIPTION
Updates a doc example showing v1 syntax.

Switched to ubi for installing tools to remove arbitrary shell script
invocation.
