### PR TITLE
feat(blocks): allow hyphens in name

### DIFF
--- a/internal/codegen/blocks.go
+++ b/internal/codegen/blocks.go
@@ -41,11 +41,11 @@ type blockInfo struct {
 
 // blockPattern is the regex used for parsing block commands.
 // For unit testing of this regex and explanation, see https://regex101.com/r/nFgOz0/1
-var blockPattern = regexp.MustCompile(`^\s*(///|###|<!---)\s*([a-zA-Z ]+)\(([a-zA-Z0-9 ]+)\)`)
+var blockPattern = regexp.MustCompile(`^\s*(///|###|<!---)\s*([a-zA-Z ]+)\(([a-zA-Z0-9 -]+)\)`)
 
 // v2BlockPattern is the new regex for parsing blocks
 // For unit testing of this regex and explanation, see https://regex101.com/r/EHkH5O/1
-var v2BlockPattern = regexp.MustCompile(`^\s*(//|##|--|<!--)\s{0,1}<<(/?)Stencil::([a-zA-Z ]+)(\([a-zA-Z0-9 ]+\))?>>`)
+var v2BlockPattern = regexp.MustCompile(`^\s*(//|##|--|<!--)\s{0,1}<<(/?)Stencil::([a-zA-Z ]+)(\([a-zA-Z0-9 -]+\))?>>`)
 
 // parseBlocks reads the blocks from an existing file, potentially adopting blocks based on the source template,
 // if so specified

--- a/internal/codegen/blocks_test.go
+++ b/internal/codegen/blocks_test.go
@@ -19,7 +19,7 @@ func fakeBlocksTemplate() *Template {
 func TestParseBlocks(t *testing.T) {
 	blocks, err := parseBlocks("testdata/blocks-test.txt", fakeBlocksTemplate())
 	assert.NilError(t, err, "expected parseBlocks() not to fail")
-	assert.Equal(t, blocks["helloWorld"].Contents, "Hello, world!", "expected parseBlocks() to parse basic block")
+	assert.Equal(t, blocks["hello-world"].Contents, "Hello, world!", "expected parseBlocks() to parse basic block")
 	assert.Equal(t, blocks["e2e"].Contents, "content", "expected parseBlocks() to parse e2e block")
 }
 

--- a/internal/codegen/testdata/blocks-test.txt
+++ b/internal/codegen/testdata/blocks-test.txt
@@ -1,6 +1,6 @@
-###Block(helloWorld)
+###Block(hello-world)
 Hello, world!
-###EndBlock(helloWorld)
+###EndBlock(hello-world)
 
 ###Block(e2e)
 content

--- a/internal/codegen/tpl_stencil_test.go
+++ b/internal/codegen/tpl_stencil_test.go
@@ -36,8 +36,8 @@ func TestTplStencil_ReadBlocks(t *testing.T) {
 				fpath: "testdata/blocks-test.txt",
 			},
 			want: map[string]string{
-				"helloWorld": "Hello, world!",
-				"e2e":        "content",
+				"hello-world": "Hello, world!",
+				"e2e":         "content",
 			},
 		},
 		{


### PR DESCRIPTION
Adds support for `-` in the name of a block.
