### PR TITLE
feat(golang): upgrade to 1.24

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -2,13 +2,13 @@
 # Default versions of tools, to update these, set [tools.override]
 [tools]
 bun = "latest"
-golang = "1.23.5"
-"go:gotest.tools/gotestsum" = "v1.12.0"
+golang = "1.24.0"
+"go:gotest.tools/gotestsum" = "1.12.0"
 "go:golang.org/x/tools/cmd/goimports" = "latest"
 "go:mvdan.cc/sh/v3/cmd/shfmt" = "latest"
 "go:github.com/thenativeweb/get-next-version" = "latest"
 "go:sigs.k8s.io/mdtoc" = "latest"
-"ubi:golangci/golangci-lint" = "1.63.4"
+"ubi:golangci/golangci-lint" = "1.64.4"
 "ubi:goreleaser/goreleaser" = "2"
 "ubi:orhun/git-cliff" = "2"
 


### PR DESCRIPTION
Upgrades us to Go 1.24 and all required dependencies to faciliate doing
so.
