### PR TITLE
feat(blocks): support _ in block names and deprecate v1

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,5 +3,5 @@ stencil.lock linguist-generated
 bun.lockb linguist-generated
 
 ## <<Stencil::Block(custom)>>
-
+.mise.lock linguist-generated
 ## <</Stencil::Block>>

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -58,7 +58,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
       - name: Retrieve golangci-lint version
         run: |
-          echo "version=$(mise current ubi:golangci/golangci-lint)" >> "$GITHUB_OUTPUT"
+          echo "version=$(mise current "go:github.com/golangci/golangci-lint/cmd/golangci-lint")" >> "$GITHUB_OUTPUT"
         id: golangci_lint
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6

--- a/.mise.lock
+++ b/.mise.lock
@@ -1,0 +1,39 @@
+[tools.bun]
+version = "1.2.4"
+backend = "core:bun"
+
+[tools.go]
+version = "1.24.1"
+backend = "core:go"
+
+[tools."go:github.com/golangci/golangci-lint/cmd/golangci-lint"]
+version = "1.64.6"
+backend = "go:github.com/golangci/golangci-lint/cmd/golangci-lint"
+
+[tools."go:github.com/thenativeweb/get-next-version"]
+version = "latest"
+backend = "go:github.com/thenativeweb/get-next-version"
+
+[tools."go:golang.org/x/tools/cmd/goimports"]
+version = "0.30.0"
+backend = "go:golang.org/x/tools/cmd/goimports"
+
+[tools."go:gotest.tools/gotestsum"]
+version = "1.12.0"
+backend = "go:gotest.tools/gotestsum"
+
+[tools."go:mvdan.cc/sh/v3/cmd/shfmt"]
+version = "3.10.0"
+backend = "go:mvdan.cc/sh/v3/cmd/shfmt"
+
+[tools."go:sigs.k8s.io/mdtoc"]
+version = "1.4.0"
+backend = "go:sigs.k8s.io/mdtoc"
+
+[tools."ubi:goreleaser/goreleaser"]
+version = "2.7.0"
+backend = "ubi:goreleaser/goreleaser"
+
+[tools."ubi:orhun/git-cliff"]
+version = "2.8.0"
+backend = "ubi:orhun/git-cliff"

--- a/.mise.toml
+++ b/.mise.toml
@@ -2,13 +2,15 @@
 # Default versions of tools, to update these, set [tools.override]
 [tools]
 bun = "latest"
-golang = "1.24.0"
+golang = "1.24.1"
 "go:gotest.tools/gotestsum" = "1.12.0"
 "go:golang.org/x/tools/cmd/goimports" = "latest"
 "go:mvdan.cc/sh/v3/cmd/shfmt" = "latest"
 "go:github.com/thenativeweb/get-next-version" = "latest"
 "go:sigs.k8s.io/mdtoc" = "latest"
-"ubi:golangci/golangci-lint" = "1.64.4"
+# FIXME(jaredallard): Disabled until OOM issue is fixed.
+# "ubi:golangci/golangci-lint" = "1.64.6"
+"go:github.com/golangci/golangci-lint/cmd/golangci-lint" = "1.64.6"
 "ubi:goreleaser/goreleaser" = "2"
 "ubi:orhun/git-cliff" = "2"
 

--- a/go.work.sum
+++ b/go.work.sum
@@ -2111,8 +2111,6 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.5.2/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
-github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
-github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/zerolog v1.13.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=
 github.com/rs/zerolog v1.15.0/go.mod h1:xYTKnLHcpfU2225ny5qZjxnj9NvkumZYjJHlAThCjNc=
@@ -2569,6 +2567,7 @@ golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
 golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sync v0.10.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/sync v0.11.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/internal/codegen/blocks.go
+++ b/internal/codegen/blocks.go
@@ -56,7 +56,7 @@ var blockPattern = regexp.MustCompile(`^\s*(///|###|<!---)\s*([a-zA-Z ]+)\(([a-z
 
 // v2BlockPattern is the new regex for parsing blocks
 // For unit testing of this regex and explanation, see https://regex101.com/r/EHkH5O/1
-var v2BlockPattern = regexp.MustCompile(`^\s*(//|##|--|<!--)\s{0,1}<<(/?)Stencil::([a-zA-Z ]+)(\([a-zA-Z0-9 -_]+\))?>>`)
+var v2BlockPattern = regexp.MustCompile(`^\s*(//|##|--|<!--)\s{0,1}<<(/?)Stencil::([a-zA-Z ]+)(\([a-zA-Z0-9 _-]+\))?>>`)
 
 // parseBlocks reads the blocks from an existing file, potentially adopting blocks based on the source template,
 // if so specified

--- a/internal/codegen/blocks_test.go
+++ b/internal/codegen/blocks_test.go
@@ -12,51 +12,51 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-func fakeBlocksTemplate() *Template {
-	return &Template{}
+func fakeBlocksTemplate(t *testing.T) *Template {
+	return &Template{log: slogext.NewTestLogger(t)}
 }
 
 func TestParseBlocks(t *testing.T) {
-	blocks, err := parseBlocks("testdata/blocks-test.txt", fakeBlocksTemplate())
+	blocks, err := parseBlocks("testdata/blocks-test.txt", fakeBlocksTemplate(t))
 	assert.NilError(t, err, "expected parseBlocks() not to fail")
 	assert.Equal(t, blocks["hello-world"].Contents, "Hello, world!", "expected parseBlocks() to parse basic block")
 	assert.Equal(t, blocks["e2e"].Contents, "content", "expected parseBlocks() to parse e2e block")
 }
 
 func TestDanglingBlock(t *testing.T) {
-	_, err := parseBlocks("testdata/danglingblock-test.txt", fakeBlocksTemplate())
+	_, err := parseBlocks("testdata/danglingblock-test.txt", fakeBlocksTemplate(t))
 	assert.Error(t, err, "found dangling Block (dangles) in testdata/danglingblock-test.txt", "expected parseBlocks() to fail")
 }
 
 func TestDanglingEndBlock(t *testing.T) {
-	_, err := parseBlocks("testdata/danglingendblock-test.txt", fakeBlocksTemplate())
+	_, err := parseBlocks("testdata/danglingendblock-test.txt", fakeBlocksTemplate(t))
 	assert.Error(t, err,
 		"invalid EndBlock when not inside of a block, at testdata/danglingendblock-test.txt:8",
 		"expected parseBlocks() to fail")
 }
 
 func TestBlockInsideBlock(t *testing.T) {
-	_, err := parseBlocks("testdata/blockinsideblock-test.txt", fakeBlocksTemplate())
+	_, err := parseBlocks("testdata/blockinsideblock-test.txt", fakeBlocksTemplate(t))
 	assert.Error(t, err,
 		"invalid Block when already inside of a block, at testdata/blockinsideblock-test.txt:3",
 		"expected parseBlocks() to fail")
 }
 
 func TestWrongEndBlock(t *testing.T) {
-	_, err := parseBlocks("testdata/wrongendblock-test.txt", fakeBlocksTemplate())
+	_, err := parseBlocks("testdata/wrongendblock-test.txt", fakeBlocksTemplate(t))
 	assert.Error(t, err,
 		"invalid EndBlock, found EndBlock with name \"wrongend\" while inside of block with name \"helloWorld\", at testdata/wrongendblock-test.txt:3", //nolint:lll // Why: test
 		"expected parseBlocks() to fail")
 }
 
 func TestParseV2Blocks(t *testing.T) {
-	blocks, err := parseBlocks("testdata/v2blocks-test.txt", fakeBlocksTemplate())
+	blocks, err := parseBlocks("testdata/v2blocks-test.txt", fakeBlocksTemplate(t))
 	assert.NilError(t, err, "expected parseBlocks() not to fail")
 	assert.Equal(t, blocks["helloWorld"].Contents, "Hello, world!", "expected parseBlocks() to parse basic block")
 }
 
 func TestV2BlocksErrors(t *testing.T) {
-	_, err := parseBlocks("testdata/v2blocks-invalid.txt", fakeBlocksTemplate())
+	_, err := parseBlocks("testdata/v2blocks-invalid.txt", fakeBlocksTemplate(t))
 	if err == nil {
 		t.Fatal("expected parseBlocks() to fail")
 	}
@@ -102,22 +102,25 @@ func TestAdoptWithBlockAlreadyPresentDiffName(t *testing.T) {
 		StartLine: 2,
 		EndLine:   4,
 		Contents:  "  version: xyz",
+		Version:   BlockVersion2,
 	}
 	exp2 := blockInfo{
 		Name:      "version2",
 		StartLine: 8,
 		EndLine:   10,
 		Contents:  "  version: abc",
+		Version:   BlockVersion2,
 	}
 	exp := blockInfo{
 		Name:      "version",
 		StartLine: 7,
 		EndLine:   11,
 		Contents:  "  ## <<Stencil::Block(version2)>>\n  version: abc\n  ## <</Stencil::Block>>",
+		Version:   0, // not present in the file
 	}
-	assert.Equal(t, *blocks["version1"], exp1, "expected parseBlocks() to parse version1 block")
-	assert.Equal(t, *blocks["version2"], exp2, "expected parseBlocks() to parse version2 block")
-	assert.Equal(t, *blocks["version"], exp, "expected parseBlocks() to parse version block")
+	assert.DeepEqual(t, *blocks["version1"], exp1)
+	assert.DeepEqual(t, *blocks["version2"], exp2)
+	assert.DeepEqual(t, *blocks["version"], exp)
 }
 
 // This demonstrates that it's not a perfect system, so you might get semi unexpected results if your blocks are too similar

--- a/internal/codegen/file.go
+++ b/internal/codegen/file.go
@@ -88,6 +88,17 @@ func (f *File) Block(name string) string {
 	if !ok {
 		return ""
 	}
+
+	// If a deprecated block is loaded, warn
+	if bi.Version == BlockVersion1 {
+		f.sourceTemplate.log.Warnf(
+			"Deprecated V1 block (%s) found at %s:%d-%d",
+			name,
+			f.path,
+			bi.StartLine, bi.EndLine,
+		)
+	}
+
 	return bi.Contents
 }
 

--- a/internal/codegen/template_test.go
+++ b/internal/codegen/template_test.go
@@ -130,7 +130,7 @@ func TestGeneratedBlock(t *testing.T) {
 
 	fs, err := testmemfs.WithManifest("name: testing\n")
 	assert.NilError(t, err, "failed to testmemfs.WithManifest")
-	sm := &configuration.Manifest{Name: "testing", Arguments: map[string]interface{}{}}
+	sm := &configuration.Manifest{Name: "testing", Arguments: map[string]any{}}
 	m, err := modulestest.NewWithFS(context.Background(), "testing", fs)
 	assert.NilError(t, err, "failed to NewWithFS")
 
@@ -142,7 +142,7 @@ func TestGeneratedBlock(t *testing.T) {
 		time.Now(), []byte(generatedBlockTemplate), log, nil)
 	assert.NilError(t, err, "failed to create template")
 
-	tplf, err := NewFile(fakeFilePath, 0o644, time.Now(), fakeBlocksTemplate())
+	tplf, err := NewFile(fakeFilePath, 0o644, time.Now(), fakeBlocksTemplate(t))
 	assert.NilError(t, err, "failed to create file")
 
 	// Add the file (fake) to the template so that the template uses it for blocks


### PR DESCRIPTION
Deprecates V1 blocks by way of a persistent log message any time a v1
block is read from disk.

Adds support for `_` in block names.
