### PR TITLE
feat(upgrade): re-render stencil templates even if no changes

### DIFF
--- a/cmd/stencil/describe.go
+++ b/cmd/stencil/describe.go
@@ -40,7 +40,7 @@ func NewDescribeCommand() *cli.Command {
 		}},
 		// Empty function means the file-system will be looked at instead of
 		// trying to generate our own completion.
-		ShellComplete: func(ctx context.Context, c *cli.Command) {},
+		ShellComplete: func(_ context.Context, _ *cli.Command) {},
 		Action: func(_ context.Context, c *cli.Command) error {
 			if c.StringArg("file") == "" {
 				return errors.New("expected exactly one argument, path to file")

--- a/cmd/stencil/upgrade.go
+++ b/cmd/stencil/upgrade.go
@@ -32,6 +32,14 @@ func NewUpgradeCommand(log slogext.Logger) *cli.Command {
 		Usage:       "upgrade stencil modules",
 		Description: "Runs stencil with newer modules and updates stencil.lock to use them",
 		UsageText:   "upgrade",
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:        "skip-render-no-changes",
+				Aliases:     []string{"s"},
+				DefaultText: "Skip re-rendering templates if there's no newer versions",
+				Value:       false,
+			},
+		},
 		Action: func(ctx context.Context, c *cli.Command) error {
 			log.Infof("stencil %s", c.Root().Version)
 
@@ -45,7 +53,8 @@ func NewUpgradeCommand(log slogext.Logger) *cli.Command {
 				return fmt.Errorf("failed to parse stencil.yaml: %w", err)
 			}
 
-			return stencil.NewCommand(log, manifest, c.Bool("dry-run"), c.Bool("adopt")).Upgrade(ctx)
+			return stencil.NewCommand(log, manifest, c.Bool("dry-run"), c.Bool("adopt")).
+				Upgrade(ctx, c.Bool("skip-render-no-changes"))
 		},
 	}
 }

--- a/cmd/stencil/upgrade_test.go
+++ b/cmd/stencil/upgrade_test.go
@@ -15,6 +15,47 @@ import (
 	"gotest.tools/v3/assert"
 )
 
+// selectUpgradeCanary returns a file from the provided directory that
+// can be used as a canary for re-running stencil detection.
+func selectUpgradeCanary(t *testing.T, dir string) string {
+	dirs, err := os.ReadDir(dir)
+	assert.NilError(t, err, "expected ReadDir() to not fail")
+
+	var file string
+	for _, de := range dirs {
+		if de.IsDir() {
+			continue
+		}
+
+		// Don't use any files owned by us.
+		if de.Name() == stencil.LockfileName || de.Name() == "stencil.yaml" {
+			continue
+		}
+
+		file = filepath.Join(dir, de.Name())
+	}
+
+	t.Logf("Using %s as upgrade canary", file)
+	return file
+}
+
+// writeML writes the provided manifest and lock to their known
+// locations in the provided directory.
+func writeML(t *testing.T, mf *configuration.Manifest, lock *stencil.Lockfile, dir string) {
+	// Write the manifest and lockfile to disk
+	mfBytes, err := yaml.Marshal(mf)
+	assert.NilError(t, err, "failed to marshal manifest")
+
+	lockBytes, err := yaml.Marshal(lock)
+	assert.NilError(t, err, "failed to marshal lockfile")
+
+	err = os.WriteFile(filepath.Join(dir, "stencil.yaml"), mfBytes, 0o644)
+	assert.NilError(t, err, "failed to write manifest")
+
+	os.WriteFile(filepath.Join(dir, stencil.LockfileName), lockBytes, 0o644)
+	assert.NilError(t, err, "failed to write lockfile")
+}
+
 // TestCanUpgradeModules tests that the upgrade command can upgrade
 // modules in a project.
 func TestCanUpgradeModules(t *testing.T) {
@@ -27,7 +68,7 @@ func TestCanUpgradeModules(t *testing.T) {
 	// version. If it upgrades, we consider success. Given this is a
 	// high-level test, we rely on other unit tests to ensure that the
 	// underlying resolver works as expected.
-	mf := &configuration.Manifest{
+	writeML(t, &configuration.Manifest{
 		Name: "testing",
 		Modules: []*configuration.TemplateRepository{{
 			Name: "github.com/rgst-io/stencil-golang",
@@ -35,9 +76,7 @@ func TestCanUpgradeModules(t *testing.T) {
 		Arguments: map[string]any{
 			"org": "rgst-io",
 		},
-	}
-
-	lock := &stencil.Lockfile{
+	}, &stencil.Lockfile{
 		Modules: []*stencil.LockfileModuleEntry{{
 			Name: "github.com/rgst-io/stencil-golang",
 			Version: &resolver.Version{
@@ -46,24 +85,10 @@ func TestCanUpgradeModules(t *testing.T) {
 				Commit: "6f031a70bea1bb06fe57db48abcea52a287eae7f",
 			},
 		}},
-	}
-
-	// Write the manifest and lockfile to disk
-	mfBytes, err := yaml.Marshal(mf)
-	assert.NilError(t, err, "failed to marshal manifest")
-
-	lockBytes, err := yaml.Marshal(lock)
-	assert.NilError(t, err, "failed to marshal lockfile")
-
-	err = os.WriteFile(filepath.Join(tmpDir, "stencil.yaml"), mfBytes, 0o644)
-	assert.NilError(t, err, "failed to write manifest")
-
-	os.WriteFile(filepath.Join(tmpDir, stencil.LockfileName), lockBytes, 0o644)
-	assert.NilError(t, err, "failed to write lockfile")
+	}, tmpDir)
 
 	// Run the upgrade
-	err = testRunCommand(t, cmd, tmpDir)
-	if err != nil {
+	if err := testRunCommand(t, cmd, tmpDir); err != nil {
 		// Right now it errors due to no go.mod, so allow that error to
 		// occur. It doesn't indicate the upgrade failure.
 		assert.ErrorContains(t, err, "failed to run post run command")
@@ -85,8 +110,7 @@ func TestUpgradeIncludesNewModules(t *testing.T) {
 	cmd := NewUpgradeCommand(slogext.NewTestLogger(t))
 	assert.Assert(t, cmd != nil, "expected NewUpgradeCommand() to not return nil")
 
-	// Create a project with no modules. If it upgrades, we consider success.
-	mf := &configuration.Manifest{
+	writeML(t, &configuration.Manifest{
 		Name: "testing",
 		Modules: []*configuration.TemplateRepository{{
 			Name: "github.com/rgst-io/stencil-golang",
@@ -94,24 +118,9 @@ func TestUpgradeIncludesNewModules(t *testing.T) {
 		Arguments: map[string]any{
 			"org": "rgst-io",
 		},
-	}
-
-	lock := &stencil.Lockfile{
+	}, &stencil.Lockfile{
 		Modules: []*stencil.LockfileModuleEntry{},
-	}
-
-	// Write the manifest and lockfile to disk
-	mfBytes, err := yaml.Marshal(mf)
-	assert.NilError(t, err, "failed to marshal manifest")
-
-	lockBytes, err := yaml.Marshal(lock)
-	assert.NilError(t, err, "failed to marshal lockfile")
-
-	err = os.WriteFile(filepath.Join(tmpDir, "stencil.yaml"), mfBytes, 0o644)
-	assert.NilError(t, err, "failed to write manifest")
-
-	os.WriteFile(filepath.Join(tmpDir, stencil.LockfileName), lockBytes, 0o644)
-	assert.NilError(t, err, "failed to write lockfile")
+	}, tmpDir)
 
 	// Run the upgrade
 	assert.NilError(t, testRunCommand(t, cmd, tmpDir), "expected upgrade to not error")
@@ -121,4 +130,66 @@ func TestUpgradeIncludesNewModules(t *testing.T) {
 	assert.NilError(t, err, "expected LoadLockfile() to not error")
 	assert.Equal(t, len(lf.Modules), 1, "expected exactly one module in lockfile")
 	assert.Check(t, lf.Modules[0].Version.Tag != "", "expected module to be latest version")
+}
+
+// TestUpgradeReRunsStencil tests an upgrade command re-runs stencil
+// even when there is no new version.
+func TestUpgradeReRunsStencil(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	cmd := NewUpgradeCommand(slogext.NewTestLogger(t))
+	assert.Assert(t, cmd != nil, "expected NewUpgradeCommand() to not return nil")
+
+	writeML(t, &configuration.Manifest{
+		Name: "testing",
+		Modules: []*configuration.TemplateRepository{{
+			Name: "github.com/rgst-io/stencil-golang",
+		}},
+		Arguments: map[string]any{
+			"org": "rgst-io",
+		},
+	}, &stencil.Lockfile{
+		Modules: []*stencil.LockfileModuleEntry{},
+	}, tmpDir)
+
+	// Run the upgrade
+	assert.NilError(t, testRunCommand(t, cmd, tmpDir), "expected upgrade to not error")
+
+	file := selectUpgradeCanary(t, tmpDir)
+	assert.NilError(t, os.Remove(file))
+	assert.NilError(t, testRunCommand(t, cmd, tmpDir), "expected upgrade to not error")
+
+	_, err := os.Stat(file)
+	assert.NilError(t, err, "expected file %s to exist", file)
+}
+
+// TestUpgradeDoesNotReRunStencilWhenTold tests an upgrade command does
+// not re-run stencil when told to do so via a flag.
+func TestUpgradeDoesNotReRunStencilWhenTold(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	cmd := NewUpgradeCommand(slogext.NewTestLogger(t))
+	assert.Assert(t, cmd != nil, "expected NewUpgradeCommand() to not return nil")
+
+	writeML(t, &configuration.Manifest{
+		Name: "testing",
+		Modules: []*configuration.TemplateRepository{{
+			Name: "github.com/rgst-io/stencil-golang",
+		}},
+		Arguments: map[string]any{
+			"org": "rgst-io",
+		},
+	}, &stencil.Lockfile{
+		Modules: []*stencil.LockfileModuleEntry{},
+	}, tmpDir)
+
+	// Run the upgrade
+	assert.NilError(t, testRunCommand(t, cmd, tmpDir), "expected upgrade to not error")
+
+	file := selectUpgradeCanary(t, tmpDir)
+	assert.NilError(t, os.Remove(file))
+	assert.NilError(t, testRunCommand(t, cmd, tmpDir, "--skip-render-no-changes"), "expected upgrade to not error")
+
+	_, err := os.Stat(file)
+	assert.ErrorIs(t, err, os.ErrNotExist, "expected file %s to not exist", file)
 }

--- a/internal/cmd/stencil/stencil.go
+++ b/internal/cmd/stencil/stencil.go
@@ -195,7 +195,10 @@ func (c *Command) resolveModules(ctx context.Context, ignoreLockfile bool) ([]*m
 // Upgrade checks for upgrades to the modules in the project and
 // upgrades them if necessary. If no lockfile is present, it will
 // log a message and return without doing anything.
-func (c *Command) Upgrade(ctx context.Context) error {
+//
+// If skipRender is true, then re-render will be skipped if there's no
+// changes. Otherwise, stencil will be ran anyways.
+func (c *Command) Upgrade(ctx context.Context, skipRender bool) error {
 	if c.lock == nil {
 		c.log.Info("No lockfile found, run 'stencil' to fetch dependencies first")
 		return nil
@@ -233,7 +236,7 @@ func (c *Command) Upgrade(ctx context.Context) error {
 			hadChanges = true
 		}
 	}
-	if !hadChanges {
+	if skipRender && !hadChanges {
 		c.log.Info("No new versions found")
 		return nil
 	}


### PR DESCRIPTION
Some users want to re-run stencil all the time and not cherry-pick their
versions. We support this by always re-running stencil (a render) even
if there is no new versions of modules added.

The old behaviour can be kept with the new `-s` and
`--skip-render-no-changes` flag.
