### PR TITLE
test: pin stencil-golang

### DIFF
--- a/cmd/stencil/upgrade_test.go
+++ b/cmd/stencil/upgrade_test.go
@@ -148,7 +148,8 @@ func TestUpgradeReRunsStencil(t *testing.T) {
 	writeML(t, &configuration.Manifest{
 		Name: "testing",
 		Modules: []*configuration.TemplateRepository{{
-			Name: "github.com/rgst-io/stencil-golang",
+			Name:    "github.com/rgst-io/stencil-golang",
+			Version: "=1.6.2",
 		}},
 		Arguments: map[string]any{
 			"org": "rgst-io",
@@ -179,7 +180,8 @@ func TestUpgradeDoesNotReRunStencilWhenTold(t *testing.T) {
 	writeML(t, &configuration.Manifest{
 		Name: "testing",
 		Modules: []*configuration.TemplateRepository{{
-			Name: "github.com/rgst-io/stencil-golang",
+			Name:    "github.com/rgst-io/stencil-golang",
+			Version: "=1.6.2",
 		}},
 		Arguments: map[string]any{
 			"org": "rgst-io",


### PR DESCRIPTION
Not needed for the actual test behaviour to be validated and prevents
upstream from breaking the test on accident.
