### PR TITLE
feat(codegen): add functions to (de)serialize TOML

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module go.rgst.io/stencil/v2
 go 1.24
 
 require (
+	github.com/BurntSushi/toml v1.5.0
 	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/caarlos0/go-version v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 dario.cat/mergo v1.0.1 h1:Ra4+bf83h2ztPIQYNP99R6m+Y7KfnARDfID+a+vLl4s=
 dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
+github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
+github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.3.1 h1:QtNSWtVZ3nBfk8mAOu/B6v7FMJ+NHTIgUPi7rj+4nv4=

--- a/go.work.sum
+++ b/go.work.sum
@@ -1331,6 +1331,7 @@ github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=

--- a/internal/codegen/functions.go
+++ b/internal/codegen/functions.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/BurntSushi/toml"
 	"go.rgst.io/stencil/v2/internal/yaml"
 )
 
@@ -128,6 +129,31 @@ func tplError(text string) TplError {
 	return TplError{errors.New(text)}
 }
 
+// toTOML converts any value into a TOML document.
+func toTOML(v any) (string, error) {
+	// If no data, return an empty string
+	if v == nil {
+		return "", nil
+	}
+
+	data, err := toml.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSuffix(string(data), "\n"), nil
+}
+
+// fromTOML converts a TOML document into a value.
+func fromTOML(str string) (any, error) {
+	var m any
+
+	if err := toml.Unmarshal([]byte(str), &m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
 // Default are stock template functions that don't impact
 // the generation of a file. Anything that does that should be located
 // in the scope of the file renderer function instead
@@ -138,5 +164,7 @@ var Default = template.FuncMap{
 	"fromYaml":         fromYAML,
 	"toJson":           toJSON,
 	"fromJson":         fromJSON,
+	"toToml":           toTOML,
+	"fromToml":         fromTOML,
 	"error":            tplError,
 }

--- a/internal/codegen/functions_test.go
+++ b/internal/codegen/functions_test.go
@@ -74,3 +74,24 @@ func Example_fromJson() {
 	// Output:
 	// map[a:b c:d] <nil>
 }
+
+func Example_toTOML() {
+	example := map[string]any{
+		"a": "b",
+		"c": "d",
+	}
+	fmt.Println(toTOML(example))
+
+	// Output:
+	// a = "b"
+	// c = "d" <nil>
+}
+
+func Example_fromTOML() {
+	example := `a = "b"
+c = "d"
+`
+	fmt.Println(fromTOML(example))
+	// Output:
+	// map[a:b c:d] <nil>
+}


### PR DESCRIPTION
## What this PR does / why we need it

This should allow less manual TOML serialization when generating files like `.mise.toml`.

For example, this is what the code change is in `rgst-io/stencil-golang`:

```diff
diff --git a/templates/.mise.toml.tpl b/templates/.mise.toml.tpl
index 641b830..680920b 100644
--- a/templates/.mise.toml.tpl
+++ b/templates/.mise.toml.tpl
@@ -16,12 +16,7 @@
 # Default versions of tools, to update these, set [tools.override]
 [tools]
 {{- range (fromYaml (stencil.Include "defaultVers")) }}
-{{- $key := index (keys .) 0 }}
-{{- $val := index . $key }}
-{{- if contains ":" $key }}
-{{- $key = quote $key }}
-{{- end }}
-{{ $key }} = "{{ $val }}"
+{{ . | toToml }}
 {{- end }}

 [tasks.build]
```