### PR TITLE
docs: add section about git HTTPS repositories in tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,4 +5,9 @@ guidelines](https://github.com/jaredallard/jaredallard/blob/master/CONTRIBUTING.
 
 <!-- <<Stencil::Block(custom)>> -->
 
+## Additional requirements
+
+Integration tests communicate with GitHub git repositories via HTTPS,
+so make sure that is [set up correctly](https://docs.github.com/en/get-started/git-basics/about-remote-repositories#cloning-with-https-urls).
+
 <!-- <</Stencil::Block>> -->


### PR DESCRIPTION
## What this PR does / why we need it

I found this out while running `mise run test`, and apparently, I didn't set up `gh` completely on my laptop.