### PR TITLE
feat: add stencilVersion constraint to template repository manifest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,6 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/urfave/cli/v3 v3.3.8
 	go.yaml.in/yaml/v3 v3.0.4
-	golang.org/x/mod v0.26.0
 	gotest.tools/v3 v3.5.2
 	sigs.k8s.io/yaml v1.5.0
 )

--- a/go.sum
+++ b/go.sum
@@ -266,8 +266,6 @@ golang.org/x/crypto v0.37.0/go.mod h1:vg+k43peMZ0pUMhYmVAWysMK35e6ioLh3wB8ZCAfbV
 golang.org/x/exp v0.0.0-20241210194714-1829a127f884 h1:Y/Mj/94zIQQGHVSv1tTtQBDaQaJe62U9bkDZKKyhPCU=
 golang.org/x/exp v0.0.0-20241210194714-1829a127f884/go.mod h1:qj5a5QZpwLU2NLQudwIN5koi3beDhSAlJwa67PuM98c=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.26.0 h1:EGMPT//Ezu+ylkCijjPc+f4Aih7sZvaAr+O3EHBxvZg=
-golang.org/x/mod v0.26.0/go.mod h1:/j6NAhSk8iQ723BGAUyoAcn7SlD7s15Dp9Nd/SfeaFQ=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/internal/cmd/stencil/stencil.go
+++ b/internal/cmd/stencil/stencil.go
@@ -259,15 +259,19 @@ func (c *Command) validateStencilVersion(mods []*modules.Module, stencilVersion 
 	for _, m := range mods {
 		c.log.Infof(" -> %s %s", m.Name, printVersion(m.Version))
 
-		if m.Manifest.MinStencilVersion != "" && m.Manifest.StencilVersion != nil {
+		if m.Manifest.MinStencilVersion != "" && m.Manifest.StencilVersion != "" {
 			return fmt.Errorf("minStencilVersion and stencilVersion cannot be declared in the same module (%s)",
 				m.Name)
 		}
 
-		if m.Manifest.StencilVersion != nil {
-			if validated, errs := m.Manifest.StencilVersion.Validate(sgv); !validated {
+		if m.Manifest.StencilVersion != "" {
+			versionConstraint, err := semver.NewConstraint(m.Manifest.StencilVersion)
+			if err != nil {
+				return err
+			}
+			if validated, errs := versionConstraint.Validate(sgv); !validated {
 				return fmt.Errorf("stencil version %s does not match the version constraint (%s) for %s: %w",
-					stencilVersion, m.Manifest.StencilVersion.String(), m.Name, errors.Join(errs...))
+					stencilVersion, m.Manifest.StencilVersion, m.Name, errors.Join(errs...))
 			}
 		}
 

--- a/internal/cmd/stencil/testdata/bad-min-stencil-version/manifest.yaml
+++ b/internal/cmd/stencil/testdata/bad-min-stencil-version/manifest.yaml
@@ -1,0 +1,2 @@
+name: github.com/rgst-io/stencil-golang
+minStencilVersion: invalid

--- a/internal/cmd/stencil/testdata/both-stencil-versions/manifest.yaml
+++ b/internal/cmd/stencil/testdata/both-stencil-versions/manifest.yaml
@@ -1,0 +1,3 @@
+name: github.com/rgst-io/stencil-golang
+minStencilVersion: 2.0.0
+stencilVersion: ^2.0.0

--- a/internal/cmd/stencil/testdata/min-stencil-too-new/manifest.yaml
+++ b/internal/cmd/stencil/testdata/min-stencil-too-new/manifest.yaml
@@ -1,0 +1,2 @@
+name: github.com/rgst-io/stencil-golang
+minStencilVersion: 3.0.0

--- a/internal/cmd/stencil/testdata/stencil-too-new/manifest.yaml
+++ b/internal/cmd/stencil/testdata/stencil-too-new/manifest.yaml
@@ -1,0 +1,2 @@
+name: github.com/rgst-io/stencil-golang
+stencilVersion: ^1.0.0

--- a/internal/cmd/stencil/testdata/stencil-version-bad-constraint/manifest.yaml
+++ b/internal/cmd/stencil/testdata/stencil-version-bad-constraint/manifest.yaml
@@ -1,0 +1,2 @@
+name: github.com/rgst-io/stencil-golang
+stencilVersion: invalid

--- a/internal/cmd/stencil/testdata/stencil-version-matches-constraint/manifest.yaml
+++ b/internal/cmd/stencil/testdata/stencil-version-matches-constraint/manifest.yaml
@@ -1,0 +1,2 @@
+name: github.com/rgst-io/stencil-golang
+stencilVersion: ^2.0.0

--- a/internal/cmd/stencil/testdata/stencil-version-newer-than-min/manifest.yaml
+++ b/internal/cmd/stencil/testdata/stencil-version-newer-than-min/manifest.yaml
@@ -1,0 +1,2 @@
+name: github.com/rgst-io/stencil-golang
+minStencilVersion: 2.0.0

--- a/pkg/configuration/template_repository.go
+++ b/pkg/configuration/template_repository.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/Masterminds/semver/v3"
 	"go.rgst.io/stencil/v2/internal/yaml"
 )
 
@@ -35,6 +36,12 @@ type TemplateRepositoryManifest struct {
 	// MinStencilVersion is the minimum version of stencil that is required to
 	// render this module.
 	MinStencilVersion string `yaml:"minStencilVersion,omitempty"`
+
+	// StencilVersion is the version constraint which describes what
+	// versions of Stencil can render this module. It differs from
+	// MinStencilVersion in that it can, among other things, lock a
+	// module to a certain major version.
+	StencilVersion *semver.Constraints `yaml:"stencilVersion,omitempty"`
 
 	// Type stores a comma-separated list of template repository types served by the current module.
 	// Use the TemplateRepositoryTypes.Contains method to check.

--- a/pkg/configuration/template_repository.go
+++ b/pkg/configuration/template_repository.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/Masterminds/semver/v3"
 	"go.rgst.io/stencil/v2/internal/yaml"
 )
 
@@ -40,8 +39,9 @@ type TemplateRepositoryManifest struct {
 	// StencilVersion is the version constraint which describes what
 	// versions of Stencil can render this module. It differs from
 	// MinStencilVersion in that it can, among other things, lock a
-	// module to a certain major version.
-	StencilVersion *semver.Constraints `yaml:"stencilVersion,omitempty"`
+	// module to a certain major version. It conforms to the constraint
+	// syntax as supported by github.com/Masterminds/semver/v3.
+	StencilVersion string `yaml:"stencilVersion,omitempty"`
 
 	// Type stores a comma-separated list of template repository types served by the current module.
 	// Use the TemplateRepositoryTypes.Contains method to check.

--- a/schemas/manifest.jsonschema.json
+++ b/schemas/manifest.jsonschema.json
@@ -88,6 +88,10 @@
 					"type": "string",
 					"description": "MinStencilVersion is the minimum version of stencil that is required to\nrender this module."
 				},
+				"stencilVersion": {
+					"type": "string",
+					"description": "StencilVersion is the version constraint which describes what\nversions of Stencil can render this module. It differs from\nMinStencilVersion in that it can, among other things, lock a\nmodule to a certain major version. It conforms to the constraint\nsyntax as supported by github.com/Masterminds/semver/v3."
+				},
 				"type": {
 					"$ref": "#/$defs/TemplateRepositoryTypes",
 					"description": "Type stores a comma-separated list of template repository types served by the current module.\nUse the TemplateRepositoryTypes.Contains method to check."


### PR DESCRIPTION
## What this PR does / why we need it

Allows Stencil modules to use semver constraints to specify what Stencil version is required to render it. This is basically a much more powerful version of `minStencilVersion`.

## Notes for your reviewers

I intentionally prevent modules from specifying both `minStencilVersion` and `stencilVersion` as you can implement the former in the latter, but happy to discuss alternative ways of dealing with that.

We should also consider deprecating (obviously not removing) `minStencilVersion` in favor of this, although the code to implement it (and the basic tests that I added for it in this PR) is pretty small.

My original implementation had `StencilVersion` be a `*semver.Constraints` instead of a `string`, but that exposed the `Constraints` struct to the JSON schema.