### PR TITLE
feat: Use virtualfs (almost) everywhere instead of mix

### DIFF
--- a/.mise.lock
+++ b/.mise.lock
@@ -1,28 +1,17 @@
 [[tools.bun]]
-version = "1.2.21"
+version = "1.2.22"
 backend = "core:bun"
 
-[tools.bun.platforms.linux-arm64]
-checksum = "blake3:22d984cec395e7bb6791a2d5bb8695f9739ea7b716e27ea6c7536abbc58b3060"
-size = 37653949
-
-[tools.bun.platforms.linux-x64]
-checksum = "blake3:cf519ce71d7c518e211001f428ae34c2ec2a4f0484787bdf28baf7f372c94860"
-size = 39128668
-
 [tools.bun.platforms.macos-arm64]
-checksum = "blake3:b5824ab4bf0afba1d27d55d4cbec1696c3d1070f6982cbf6b4fa0489892ec931"
-size = 22056420
+checksum = "blake3:ec41528ae2badd9c5d41cefe2c463a307c46d9b5f0ccf157d6f406890340833e"
+size = 22178114
 
 [[tools.git-cliff]]
-version = "2.10.0"
+version = "2.10.1"
 backend = "ubi:orhun/git-cliff"
 
-[tools.git-cliff.platforms.linux-arm64-git-cliff]
-checksum = "blake3:08b3f66337f3d61451a7d604966fed0106f2d7b256f2dda2ce68c9582984e7f0"
-
-[tools.git-cliff.platforms.linux-x64-git-cliff]
-checksum = "blake3:ffb12e0b35ab1bd5ab862ace2131a85f94a596c5dbbb2a0d7ca662950f45ecd3"
+[tools.git-cliff.platforms.macos-arm64-git-cliff]
+checksum = "blake3:5e5de7113bd042e9868e9df6d30e6037329d37153120fe8d7cd6a112f3921084"
 
 [[tools.go]]
 version = "1.25.1"
@@ -43,7 +32,7 @@ version = "latest"
 backend = "go:github.com/thenativeweb/get-next-version"
 
 [[tools."go:golang.org/x/tools/cmd/goimports"]]
-version = "latest"
+version = "0.37.0"
 backend = "go:golang.org/x/tools/cmd/goimports"
 
 [[tools."go:gotest.tools/gotestsum"]]
@@ -51,7 +40,7 @@ version = "1.13.0"
 backend = "go:gotest.tools/gotestsum"
 
 [[tools."go:mvdan.cc/sh/v3/cmd/shfmt"]]
-version = "latest"
+version = "3.12.0"
 backend = "go:mvdan.cc/sh/v3/cmd/shfmt"
 
 [[tools.golangci-lint]]
@@ -69,20 +58,10 @@ size = 14126779
 url = "https://github.com/golangci/golangci-lint/releases/download/v2.4.0/golangci-lint-2.4.0-linux-amd64.tar.gz"
 
 [[tools.goreleaser]]
-version = "2.12.0"
+version = "2.12.2"
 backend = "aqua:goreleaser/goreleaser"
 
-[tools.goreleaser.platforms.linux-arm64]
-checksum = "sha256:d36fd20b66431dba7ee4c5ffc6f4d1b37c876d694d65ced1ff4911c143d8e66d"
-size = 23460699
-url = "https://github.com/goreleaser/goreleaser/releases/download/v2.12.0/goreleaser_Linux_arm64.tar.gz"
-
-[tools.goreleaser.platforms.linux-x64]
-checksum = "sha256:0c8915d91a491b1349fe4288eb8541d3876c5187be7f7e614bfc3fe442cf06d1"
-size = 25994939
-url = "https://github.com/goreleaser/goreleaser/releases/download/v2.12.0/goreleaser_Linux_x86_64.tar.gz"
-
 [tools.goreleaser.platforms.macos-arm64]
-checksum = "sha256:0fd9a6134389a377da88c343fb36e3d7f00b45d9d7b8b95bf25b33a3c7e8ecd6"
-size = 52187120
-url = "https://github.com/goreleaser/goreleaser/releases/download/v2.12.0/goreleaser_Darwin_all.tar.gz"
+checksum = "sha256:28e7db397dc342ed751a91b66cb8f71694bf30fe1f0850e8c7fb225a05435e9d"
+size = 52187054
+url = "https://github.com/goreleaser/goreleaser/releases/download/v2.12.2/goreleaser_Darwin_all.tar.gz"

--- a/.mise.lock
+++ b/.mise.lock
@@ -1,17 +1,28 @@
 [[tools.bun]]
-version = "1.2.22"
+version = "1.2.21"
 backend = "core:bun"
 
+[tools.bun.platforms.linux-arm64]
+checksum = "blake3:22d984cec395e7bb6791a2d5bb8695f9739ea7b716e27ea6c7536abbc58b3060"
+size = 37653949
+
+[tools.bun.platforms.linux-x64]
+checksum = "blake3:cf519ce71d7c518e211001f428ae34c2ec2a4f0484787bdf28baf7f372c94860"
+size = 39128668
+
 [tools.bun.platforms.macos-arm64]
-checksum = "blake3:ec41528ae2badd9c5d41cefe2c463a307c46d9b5f0ccf157d6f406890340833e"
-size = 22178114
+checksum = "blake3:b5824ab4bf0afba1d27d55d4cbec1696c3d1070f6982cbf6b4fa0489892ec931"
+size = 22056420
 
 [[tools.git-cliff]]
-version = "2.10.1"
+version = "2.10.0"
 backend = "ubi:orhun/git-cliff"
 
-[tools.git-cliff.platforms.macos-arm64-git-cliff]
-checksum = "blake3:5e5de7113bd042e9868e9df6d30e6037329d37153120fe8d7cd6a112f3921084"
+[tools.git-cliff.platforms.linux-arm64-git-cliff]
+checksum = "blake3:08b3f66337f3d61451a7d604966fed0106f2d7b256f2dda2ce68c9582984e7f0"
+
+[tools.git-cliff.platforms.linux-x64-git-cliff]
+checksum = "blake3:ffb12e0b35ab1bd5ab862ace2131a85f94a596c5dbbb2a0d7ca662950f45ecd3"
 
 [[tools.go]]
 version = "1.25.1"
@@ -32,7 +43,7 @@ version = "latest"
 backend = "go:github.com/thenativeweb/get-next-version"
 
 [[tools."go:golang.org/x/tools/cmd/goimports"]]
-version = "0.37.0"
+version = "latest"
 backend = "go:golang.org/x/tools/cmd/goimports"
 
 [[tools."go:gotest.tools/gotestsum"]]
@@ -40,7 +51,7 @@ version = "1.13.0"
 backend = "go:gotest.tools/gotestsum"
 
 [[tools."go:mvdan.cc/sh/v3/cmd/shfmt"]]
-version = "3.12.0"
+version = "latest"
 backend = "go:mvdan.cc/sh/v3/cmd/shfmt"
 
 [[tools.golangci-lint]]
@@ -58,10 +69,20 @@ size = 14126779
 url = "https://github.com/golangci/golangci-lint/releases/download/v2.4.0/golangci-lint-2.4.0-linux-amd64.tar.gz"
 
 [[tools.goreleaser]]
-version = "2.12.2"
+version = "2.12.0"
 backend = "aqua:goreleaser/goreleaser"
 
+[tools.goreleaser.platforms.linux-arm64]
+checksum = "sha256:d36fd20b66431dba7ee4c5ffc6f4d1b37c876d694d65ced1ff4911c143d8e66d"
+size = 23460699
+url = "https://github.com/goreleaser/goreleaser/releases/download/v2.12.0/goreleaser_Linux_arm64.tar.gz"
+
+[tools.goreleaser.platforms.linux-x64]
+checksum = "sha256:0c8915d91a491b1349fe4288eb8541d3876c5187be7f7e614bfc3fe442cf06d1"
+size = 25994939
+url = "https://github.com/goreleaser/goreleaser/releases/download/v2.12.0/goreleaser_Linux_x86_64.tar.gz"
+
 [tools.goreleaser.platforms.macos-arm64]
-checksum = "sha256:28e7db397dc342ed751a91b66cb8f71694bf30fe1f0850e8c7fb225a05435e9d"
-size = 52187054
-url = "https://github.com/goreleaser/goreleaser/releases/download/v2.12.2/goreleaser_Darwin_all.tar.gz"
+checksum = "sha256:0fd9a6134389a377da88c343fb36e3d7f00b45d9d7b8b95bf25b33a3c7e8ecd6"
+size = 52187120
+url = "https://github.com/goreleaser/goreleaser/releases/download/v2.12.0/goreleaser_Darwin_all.tar.gz"

--- a/internal/codegen/blocks.go
+++ b/internal/codegen/blocks.go
@@ -61,8 +61,12 @@ var v2BlockPattern = regexp.MustCompile(`^\s*(//|##|--|<!--)\s{0,1}<<(/?)Stencil
 // parseBlocks reads the blocks from an existing file, potentially adopting blocks based on the source template,
 // if so specified
 func parseBlocks(filePath string, sourceTemplate *Template) (map[string]*blockInfo, error) {
-	//nolint:gosec // Why: By design and acceptable.
-	f, err := os.Open(filePath)
+	fs, err := sourceTemplate.Module.GetFS(sourceTemplate.args.Context)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get fs for source template %q", sourceTemplate.Path)
+	}
+
+	f, err := fs.Open(filePath)
 	if errors.Is(err, os.ErrNotExist) {
 		return make(map[string]*blockInfo), nil
 	} else if err != nil {

--- a/internal/codegen/blocks_test.go
+++ b/internal/codegen/blocks_test.go
@@ -142,7 +142,7 @@ func TestAdoptWithBadBlock(t *testing.T) {
 func adoptTestHelper(t *testing.T, templateFile, targetFile string) map[string]*blockInfo {
 	fs, err := testmemfs.WithManifest("name: testing\n")
 	assert.NilError(t, err, "failed to testmemfs.WithManifest")
-	m, err := modulestest.NewWithFS(t.Context(), "testing", fs)
+	m, err := modulestest.NewWithFS(t, "testing", fs)
 	log := slogext.NewTestLogger(t)
 	assert.NilError(t, err, "failed to NewWithFS")
 

--- a/internal/codegen/stencil_test.go
+++ b/internal/codegen/stencil_test.go
@@ -35,7 +35,7 @@ func TestBasicE2ERender(t *testing.T) {
 	f.Write([]byte("{{ .Config.Name }}"))
 	f.Close()
 
-	tp, err := modulestest.NewWithFS(ctx, "testing", fs)
+	tp, err := modulestest.NewWithFS(t, "testing", fs)
 	assert.NilError(t, err, "failed to NewWithFS")
 	st := NewStencil(&configuration.Manifest{
 		Name:      "test",
@@ -76,14 +76,14 @@ func TestModuleHookRender(t *testing.T) {
 	m1man := &configuration.TemplateRepositoryManifest{
 		Name: "testing1",
 	}
-	m1, err := modulestest.NewModuleFromTemplates(m1man, "testdata/module-hook/m1.tpl")
+	m1, err := modulestest.NewModuleFromTemplates(t, m1man, "testdata/module-hook/m1.tpl")
 	if err != nil {
 		t.Errorf("failed to create module 1: %v", err)
 	}
 	m2man := &configuration.TemplateRepositoryManifest{
 		Name: "testing2",
 	}
-	m2, err := modulestest.NewModuleFromTemplates(m2man, "testdata/module-hook/m2.tpl")
+	m2, err := modulestest.NewModuleFromTemplates(t, m2man, "testdata/module-hook/m2.tpl")
 	if err != nil {
 		t.Errorf("failed to create module 2: %v", err)
 	}
@@ -115,7 +115,7 @@ func TestDirReplacementRendering(t *testing.T) {
 		},
 		Arguments: map[string]configuration.Argument{"x": {Schema: map[string]any{"type": "string"}}},
 	}
-	m1, err := modulestest.NewModuleFromTemplates(m1man, "testdata/replacement/m1.tpl")
+	m1, err := modulestest.NewModuleFromTemplates(t, m1man, "testdata/replacement/m1.tpl")
 	assert.NilError(t, err, "failed to NewWithFS")
 
 	st := NewStencil(sm, nil, []*modules.Module{m1}, log, false)
@@ -133,7 +133,7 @@ func TestBinaryRender(t *testing.T) {
 	m1man := &configuration.TemplateRepositoryManifest{
 		Name: "testing1",
 	}
-	m1, err := modulestest.NewModuleFromTemplates(m1man, "testdata/binary.nontpl")
+	m1, err := modulestest.NewModuleFromTemplates(t, m1man, "testdata/binary.nontpl")
 	assert.NilError(t, err, "failed to NewWithFS")
 
 	st := NewStencil(sm, nil, []*modules.Module{m1}, log, false)
@@ -165,7 +165,7 @@ func TestBadDirReplacement(t *testing.T) {
 	log := slogext.NewTestLogger(t)
 	sm := &configuration.Manifest{Name: "testing"}
 	m1man := &configuration.TemplateRepositoryManifest{Name: "testing1"}
-	m, err := modulestest.NewModuleFromTemplates(m1man, "testdata/replacement/m1.tpl")
+	m, err := modulestest.NewModuleFromTemplates(t, m1man, "testdata/replacement/m1.tpl")
 	assert.NilError(t, err, "failed to NewModuleFromTemplates")
 
 	st := NewStencil(sm, nil, []*modules.Module{m}, log, false)
@@ -198,7 +198,7 @@ two: {{ stencil.GetGlobal "y" }}
 three: {{ stencil.GetGlobal "z" }}`))
 	assert.NilError(t, f.Close(), "failed to close stub template")
 
-	tp, err := modulestest.NewWithFS(ctx, "testing", fs)
+	tp, err := modulestest.NewWithFS(t, "testing", fs)
 	assert.NilError(t, err, "failed to NewWithFS")
 	st := NewStencil(&configuration.Manifest{
 		Name:      "test",

--- a/internal/codegen/template.go
+++ b/internal/codegen/template.go
@@ -140,6 +140,9 @@ func (t *Template) Parse(_ *Stencil) error {
 // Render renders the provided template, the produced files
 // are rendered onto the Files field of the template struct.
 func (t *Template) Render(st *Stencil, vals *Values) error {
+	// Update the module values
+	t.args = vals.WithModule(t.Module.Name, t.Module.Version).WithTemplate(t.Path)
+
 	if len(t.Files) == 0 && !t.Library {
 		var p string
 		if t.Binary {
@@ -166,9 +169,6 @@ func (t *Template) Render(st *Stencil, vals *Values) error {
 		t.Files[0].SetContents(string(t.Contents))
 		return nil
 	}
-
-	// Update the module values
-	t.args = vals.WithModule(t.Module.Name, t.Module.Version).WithTemplate(t.Path)
 
 	// Execute a specific file because we're using a shared template, if we attempt to render
 	// the entire template we'll end up just rendering the base template (<module>) which is empty

--- a/internal/codegen/template_test.go
+++ b/internal/codegen/template_test.go
@@ -110,7 +110,7 @@ func TestGeneratedBlock(t *testing.T) {
 	fs, err := testmemfs.WithManifest("name: testing\n")
 	assert.NilError(t, err, "failed to testmemfs.WithManifest")
 	sm := &configuration.Manifest{Name: "testing", Arguments: map[string]any{}}
-	m, err := modulestest.NewWithFS(t.Context(), "testing", fs)
+	m, err := modulestest.NewWithFS(t, "testing", fs)
 	assert.NilError(t, err, "failed to NewWithFS")
 
 	st := NewStencil(sm, nil, []*modules.Module{m}, log, false)
@@ -139,7 +139,7 @@ func TestGeneratedBlockIndent(t *testing.T) {
 	fs, err := testmemfs.WithManifest("name: testing\n")
 	assert.NilError(t, err, "failed to testmemfs.WithManifest")
 	sm := &configuration.Manifest{Name: "testing", Arguments: map[string]any{}}
-	m, err := modulestest.NewWithFS(t.Context(), "testing", fs)
+	m, err := modulestest.NewWithFS(t, "testing", fs)
 	assert.NilError(t, err, "failed to NewWithFS")
 
 	st := NewStencil(sm, nil, []*modules.Module{m}, log, false)
@@ -165,7 +165,7 @@ func TestGeneratedBlockIndent(t *testing.T) {
 func TestLibraryTemplate(t *testing.T) {
 	fs, err := testmemfs.WithManifest("name: testing\n")
 	assert.NilError(t, err, "failed to testmemfs.WithManifest")
-	m, err := modulestest.NewWithFS(t.Context(), "testing", fs)
+	m, err := modulestest.NewWithFS(t, "testing", fs)
 	log := slogext.NewTestLogger(t)
 	assert.NilError(t, err, "failed to NewWithFS")
 
@@ -186,7 +186,7 @@ func TestLibraryTemplate(t *testing.T) {
 func TestLibraryCantAccessFileFunctions(t *testing.T) {
 	fs, err := testmemfs.WithManifest("name: testing\n")
 	assert.NilError(t, err, "failed to testmemfs.WithManifest")
-	m, err := modulestest.NewWithFS(t.Context(), "testing", fs)
+	m, err := modulestest.NewWithFS(t, "testing", fs)
 	log := slogext.NewTestLogger(t)
 	assert.NilError(t, err, "failed to NewWithFS")
 

--- a/internal/codegen/templatetest_test.go
+++ b/internal/codegen/templatetest_test.go
@@ -20,6 +20,8 @@
 package codegen
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -57,7 +59,7 @@ func RenderTemplate(
 		trmf.Name = t.Name() + "Module"
 	}
 
-	m, err := modulestest.NewModuleFromTemplates(trmf)
+	m, err := modulestest.NewModuleFromTemplates(t, trmf)
 	assert.NilError(t, err, "expected module creation to not fail")
 
 	tpl, err := NewTemplate(m, "test.tpl", 0o755, time.Now(), []byte(contents), log, &NewTemplateOpts{})
@@ -67,4 +69,100 @@ func RenderTemplate(
 	assert.NilError(t, tpl.Render(st, NewValues(t.Context(), mf, []*modules.Module{m})), "expected render to not fail")
 
 	return tpl
+}
+
+type quickTemplate struct {
+	Filename             string
+	TemplateContents     string
+	ExistingFileContents string
+}
+
+func RenderTemplates(
+	t *testing.T,
+	mf *configuration.Manifest,
+	trmf *configuration.TemplateRepositoryManifest,
+	contents ...quickTemplate,
+) []*Template {
+	log := slogext.NewTestLogger(t)
+
+	if mf == nil {
+		mf = &configuration.Manifest{}
+	}
+	if mf.Name == "" {
+		mf.Name = t.Name()
+	}
+
+	if trmf == nil {
+		trmf = &configuration.TemplateRepositoryManifest{}
+	}
+	if trmf.Name == "" {
+		trmf.Name = t.Name() + "Module"
+	}
+
+	m, err := modulestest.NewModuleFromTemplates(t, trmf)
+	assert.NilError(t, err, "expected module creation to not fail")
+
+	st := NewStencil(mf, nil, []*modules.Module{m}, log, false)
+
+	tpls := make([]*Template, len(contents))
+
+	fs, err := m.GetFS(t.Context())
+	assert.NilError(t, err, "expected module to have fs")
+
+	for i, qt := range contents {
+		if qt.ExistingFileContents != "" {
+			f, err := fs.Create(qt.Filename)
+			assert.NilError(t, err, "expected create to work")
+			_, err = f.Write([]byte(qt.ExistingFileContents))
+			assert.NilError(t, err, "expected write to work")
+			assert.NilError(t, f.Close(), "expected close to work")
+		}
+		tpl, err := NewTemplate(m, qt.Filename+".tpl", 0o755, time.Now(), []byte(qt.TemplateContents), log, &NewTemplateOpts{})
+		assert.NilError(t, err, "expected template creation to not fail")
+		assert.NilError(t, tpl.Render(st, NewValues(t.Context(), mf, []*modules.Module{m})), "expected render to not fail")
+		tpls[i] = tpl
+	}
+
+	return tpls
+}
+
+func MoveFileToVFS(t *testing.T, tpl *Template, fpath string) []byte {
+	contents, err := os.ReadFile(fpath)
+	assert.NilError(t, err, "expected os.ReadFile to succeed")
+
+	fs, err := tpl.Module.GetFS(t.Context())
+	assert.NilError(t, err, "expected GetFS to succeed")
+	fpb := filepath.Base(fpath)
+	if fpb != "" {
+		assert.NilError(t, fs.MkdirAll(fpb, 0o755), "expected MkdirAll to succeed")
+	}
+	btf, err := fs.Create(fpath)
+	assert.NilError(t, err, "expected OpenFile to succeed")
+	_, err = btf.Write(contents)
+	assert.NilError(t, err, "expected Write to succeed")
+	assert.NilError(t, btf.Close(), "expected Close to succeed")
+
+	return contents
+}
+
+func MoveDirToVFS(t *testing.T, tpl *Template, fpath string) {
+	contents, err := os.ReadDir(fpath)
+	assert.NilError(t, err, "expected os.ReadDir to succeed")
+
+	for _, entry := range contents {
+		if entry.IsDir() {
+			MoveDirToVFS(t, tpl, filepath.Join(fpath, entry.Name()))
+			continue
+		}
+		MoveFileToVFS(t, tpl, filepath.Join(fpath, entry.Name()))
+	}
+}
+
+func NewTestTemplate(t *testing.T, m *modules.Module, fpath string, mode os.FileMode,
+	modTime time.Time, contents []byte, log slogext.Logger, opts *NewTemplateOpts) (*Template, error) {
+	tp, err := NewTemplate(m, fpath, mode, modTime, contents, log, opts)
+	tp.args = &Values{Context: t.Context()}
+	tp.Module = m
+	assert.NilError(t, err, "expected template creation to not fail")
+	return tp, err
 }

--- a/internal/codegen/tpl_file_test.go
+++ b/internal/codegen/tpl_file_test.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"testing"
 
+	"go.rgst.io/stencil/v2/internal/modules"
 	"go.rgst.io/stencil/v2/pkg/slogext"
 	"go.rgst.io/stencil/v2/pkg/stencil"
 	"gotest.tools/v3/assert"
@@ -140,7 +141,7 @@ func TestTplFile_OnceLockHasHistoryOfOtherFile(t *testing.T) {
 func TestTplFile_OnceLockHasHistoryOfFile(t *testing.T) {
 	tplf := TplFile{
 		f:   &File{path: "test.go"},
-		t:   &Template{},
+		t:   &Template{args: &Values{Context: t.Context()}},
 		log: slogext.NewTestLogger(t),
 		lock: &stencil.Lockfile{
 			Files: []*stencil.LockfileFileEntry{
@@ -158,6 +159,7 @@ func TestTplFile_OnceLockHasHistoryOfFile(t *testing.T) {
 func TestTplFile_MigrateToSrcFileExistsNoDestFile(t *testing.T) {
 	tplf := TplFile{
 		f:   &File{path: path.Join(t.TempDir(), "test.go")},
+		t:   &Template{args: &Values{Context: t.Context()}, Module: &modules.Module{Name: "test"}},
 		log: slogext.NewTestLogger(t),
 	}
 
@@ -187,6 +189,7 @@ func TestTplFile_MigrateToSrcFileExistsNoDestFile(t *testing.T) {
 func TestTplFile_MigrateToSrcFileExistsDestFileExists(t *testing.T) {
 	tplf := TplFile{
 		f:   &File{path: path.Join(t.TempDir(), "test.go")},
+		t:   &Template{args: &Values{Context: t.Context()}, Module: &modules.Module{Name: "test"}},
 		log: slogext.NewTestLogger(t),
 	}
 
@@ -217,7 +220,7 @@ func TestTplFile_MigrateToSrcFileExistsDestFileExists(t *testing.T) {
 func TestTplFile_MigrateToSrcFileNoExists(t *testing.T) {
 	tplf := TplFile{
 		f:   &File{path: path.Join(t.TempDir(), "test.go")},
-		t:   &Template{},
+		t:   &Template{args: &Values{Context: t.Context()}, Module: &modules.Module{Name: "test"}},
 		log: slogext.NewTestLogger(t),
 	}
 

--- a/internal/codegen/tpl_module_test.go
+++ b/internal/codegen/tpl_module_test.go
@@ -110,13 +110,13 @@ func TestTplModule_Tpl(t *testing.T) {
 			st := &Stencil{sharedState: newSharedState(), log: log}
 
 			// create calling module
-			callerModule, err := modulestest.NewModuleFromTemplates(&configuration.TemplateRepositoryManifest{
+			callerModule, err := modulestest.NewModuleFromTemplates(t, &configuration.TemplateRepositoryManifest{
 				Name: "caller",
 			})
 			assert.NilError(t, err, "expected NewModuleFromTemplates to succeed")
 
 			// create function template for module
-			functionModule, err := modulestest.NewModuleFromTemplates(&configuration.TemplateRepositoryManifest{
+			functionModule, err := modulestest.NewModuleFromTemplates(t, &configuration.TemplateRepositoryManifest{
 				Name: "function",
 			})
 			assert.NilError(t, err, "expected NewModuleFromTemplates to succeed")

--- a/internal/codegen/tpl_stencil_arg_test.go
+++ b/internal/codegen/tpl_stencil_arg_test.go
@@ -30,7 +30,7 @@ func fakeTemplate(t *testing.T, args map[string]any,
 		Name:      "test",
 		Arguments: requestArgs,
 	}
-	m, err := modulestest.NewModuleFromTemplates(man)
+	m, err := modulestest.NewModuleFromTemplates(t, man)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,7 +89,7 @@ func fakeTemplateMultipleModules(t *testing.T, manifestArgs map[string]any,
 		}
 
 		var err error
-		mods[i], err = modulestest.NewModuleFromTemplates(&configuration.TemplateRepositoryManifest{
+		mods[i], err = modulestest.NewModuleFromTemplates(t, &configuration.TemplateRepositoryManifest{
 			Name:      fmt.Sprintf("test-%d", i),
 			Arguments: args[i],
 			Modules:   deps,

--- a/internal/codegen/values.go
+++ b/internal/codegen/values.go
@@ -111,6 +111,9 @@ func (m modulesSlice) ByName(name string) module {
 // stencil template. When updating this struct, ensure that the receiver
 // functions are updated to reflect the new fields.
 type Values struct {
+	// Context is the context being used to render the template
+	Context context.Context
+
 	// Git is information about the current git repository, if there is one
 	Git git
 
@@ -159,7 +162,8 @@ func (v *Values) WithTemplate(name string) *Values {
 // based on the current runtime environment.
 func NewValues(ctx context.Context, sm *configuration.Manifest, mods []*modules.Module) *Values {
 	vals := &Values{
-		Git: git{},
+		Context: ctx,
+		Git:     git{},
 		Runtime: runtimeVals{
 			Generator:        "stencil",
 			GeneratorVersion: version.Version.GitVersion,

--- a/internal/codegen/values_test.go
+++ b/internal/codegen/values_test.go
@@ -8,6 +8,7 @@ import (
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/jaredallard/vcs/resolver"
 	"go.rgst.io/stencil/v2/internal/modules"
 	"go.rgst.io/stencil/v2/internal/modules/modulestest"
@@ -60,6 +61,7 @@ func TestValues(t *testing.T) {
 		},
 	})
 	assert.DeepEqual(t, &Values{
+		Context: t.Context(),
 		Git: git{
 			Ref:           plumbing.NewBranchReferenceName("main").String(),
 			Commit:        cmt.String(),
@@ -79,7 +81,7 @@ func TestValues(t *testing.T) {
 		Config: config{
 			Name: sm.Name,
 		},
-	}, vals)
+	}, vals, cmpopts.EquateComparable(t.Context()))
 }
 
 func TestGeneratedValues(t *testing.T) {
@@ -88,7 +90,7 @@ func TestGeneratedValues(t *testing.T) {
 	man := &configuration.TemplateRepositoryManifest{
 		Name: "testing",
 	}
-	m, err := modulestest.NewModuleFromTemplates(man, "testdata/values/values.tpl")
+	m, err := modulestest.NewModuleFromTemplates(t, man, "testdata/values/values.tpl")
 	assert.NilError(t, err, "failed to create module")
 
 	st := NewStencil(&configuration.Manifest{

--- a/internal/modules/module_test.go
+++ b/internal/modules/module_test.go
@@ -215,7 +215,7 @@ func TestBranchAlwaysUsedOverDependency(t *testing.T) {
 			},
 		},
 	}
-	mDep, err := modulestest.NewModuleFromTemplates(man)
+	mDep, err := modulestest.NewModuleFromTemplates(t, man)
 	assert.NilError(t, err, "failed to create dep module")
 
 	// Resolve a fake project that requires a branch of a dependency that the in-memory module also requires
@@ -263,7 +263,7 @@ func TestShouldResolveInMemoryModule(t *testing.T) {
 			{Name: "test-dep"},
 		},
 	}
-	m, err := modulestest.NewModuleFromTemplates(man)
+	m, err := modulestest.NewModuleFromTemplates(t, man)
 	assert.NilError(t, err, "failed to create module")
 
 	// this relies on the top-level to ensure that re-resolving still picks
@@ -274,7 +274,7 @@ func TestShouldResolveInMemoryModule(t *testing.T) {
 			{Name: "test"},
 		},
 	}
-	mDep, err := modulestest.NewModuleFromTemplates(man)
+	mDep, err := modulestest.NewModuleFromTemplates(t, man)
 	assert.NilError(t, err, "failed to create dep module")
 
 	mods, err := modules.FetchModules(ctx, &modules.ModuleResolveOptions{
@@ -333,7 +333,7 @@ func TestShouldErrorOnTwoDifferentBranches(t *testing.T) {
 func TestSimpleDirReplacement(t *testing.T) {
 	fs, err := testmemfs.WithManifest("name: testing\ndirReplacements:\n  a: 'b'\n")
 	assert.NilError(t, err, "failed to testmemfs.WithManifest")
-	m, err := modulestest.NewWithFS(t.Context(), "testing", fs)
+	m, err := modulestest.NewWithFS(t, "testing", fs)
 	assert.NilError(t, err, "failed to NewWithFS")
 
 	m.StoreDirReplacements(map[string]string{"a": "b"})

--- a/internal/modules/modulestest/modulestest.go
+++ b/internal/modules/modulestest/modulestest.go
@@ -21,11 +21,11 @@
 package modulestest
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"testing"
 
 	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-billy/v5/memfs"
@@ -58,7 +58,7 @@ func addTemplateToFS(fs billy.Filesystem, tpl string) error {
 
 // NewModuleFromTemplates creates a module with the provided template(s)
 // being the only file(s) in the module.
-func NewModuleFromTemplates(manifest *configuration.TemplateRepositoryManifest,
+func NewModuleFromTemplates(t *testing.T, manifest *configuration.TemplateRepositoryManifest,
 	templates ...string) (*modules.Module, error) {
 	fs := memfs.New()
 	for _, tpl := range templates {
@@ -83,11 +83,12 @@ func NewModuleFromTemplates(manifest *configuration.TemplateRepositoryManifest,
 	}
 
 	// create the module
-	return NewWithFS(context.Background(), manifest.Name, fs)
+	return NewWithFS(t, manifest.Name, fs)
 }
 
 // NewWithFS creates a module with the specified file system.
-func NewWithFS(ctx context.Context, name string, fs billy.Filesystem) (*modules.Module, error) {
+func NewWithFS(t *testing.T, name string, fs billy.Filesystem) (*modules.Module, error) {
+	ctx := t.Context()
 	return modules.New(ctx, "vfs://"+name, modules.NewModuleOpts{
 		ImportPath: name,
 		Version:    &resolver.Version{Virtual: "vfs"},


### PR DESCRIPTION
* Moved most os calls away from os. into using the billy fs
* Had to move Context into args (kinda ugly but was best spot I could find that didn't require MAJOR surgery)
* Made several reusable helpers in templatetest_test.go
* Cleaned up awkward .clean method on TplStencil
