### PR TITLE
build: remove brews section and fix license

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -63,29 +63,13 @@ notarize:
         key_id: "{{.Env.MACOS_NOTARY_KEY_ID}}"
         key: "{{.Env.MACOS_NOTARY_KEY}}"
 
-brews:
-  - commit_author:
-      name: GitHub Actions
-      email: 41898282+github-actions[bot]@users.noreply.github.com
-    homepage: https://stencil.rgst.io
-    license: Apache-2.0
-    description: "A modern living-template engine for evolving repositories"
-    dependencies:
-      - name: git
-        os: mac
-    conflicts:
-      - stencil
-    repository:
-      owner: rgst-io
-      name: homebrew-tap
-      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN}}"
 nfpms:
   - id: packages
     homepage: https://stencil.rgst.io
     description: |-
       A modern living-template engine for evolving repositories.
     maintainer: Jared Allard <jared@rgst.io>
-    license: MIT
+    license: Apache-2.0
     vendor: rgst
     bindir: /usr/bin
     section: utils


### PR DESCRIPTION
`brews` is deprecated[^1] and we migrated to Homebrew core awhile ago,
so we're free to stop pushing to the rgst-io tap.

License for DEB, RPM and APK was marked as MIT for some reason, fixed to
reflect Apache-2.0

[^1]: https://goreleaser.com/deprecations/#brews
