### PR TITLE
feat: parse generated .stencilignore

### DIFF
--- a/cmd/stencil/stencil.go
+++ b/cmd/stencil/stencil.go
@@ -28,6 +28,7 @@ import (
 	"go.rgst.io/stencil/v2/internal/cmd/stencil"
 	"go.rgst.io/stencil/v2/internal/version"
 	"go.rgst.io/stencil/v2/pkg/configuration"
+	stencilpub "go.rgst.io/stencil/v2/pkg/stencil"
 )
 
 // Set the version printer to do nothing but print the version.
@@ -105,7 +106,7 @@ func NewStencil(log slogext.Logger) *cli.Command {
 			},
 			&cli.BoolFlag{
 				Name:  "fail-ignored",
-				Usage: "Fails if there are ignored files via .stencilignore",
+				Usage: fmt.Sprintf("Fails if there are ignored files via %s", stencilpub.StencilIgnoreName),
 			},
 		},
 		EnableShellCompletion: true,

--- a/cmd/stencil/stencil_test.go
+++ b/cmd/stencil/stencil_test.go
@@ -52,3 +52,71 @@ func TestStencilKeepsIgnoredFiles(t *testing.T) {
 	assert.NilError(t, err, "expected read of go.mod to not fail")
 	assert.Equal(t, string(goModContent), "hello, world!", "expected go.mod to remain unchanged")
 }
+
+// TestStencilGeneratedIgnore ensures that if a template outputs
+// .stencilignore that it is read and respected in the same run.
+func TestStencilGeneratedIgnore(t *testing.T) {
+	cmd := NewStencil(slogext.NewTestLogger(t))
+	assert.Assert(t, cmd != nil, "expected NewStencil() to not return nil")
+
+	cwd, err := os.Getwd()
+	assert.NilError(t, err, "expected getting cwd to not fail")
+
+	tmpDir := t.TempDir()
+
+	assert.NilError(t, os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte("hello, world!"), 0o644),
+		"expected write to go.mod to not fail")
+
+	manifest := &configuration.Manifest{
+		Name:         "test-123",
+		Arguments:    map[string]any{},
+		Modules:      []*configuration.TemplateRepository{{Name: "module_ignore"}},
+		Replacements: map[string]string{"module_ignore": filepath.Join(cwd, "testdata", "module_ignore")},
+	}
+	manifestBytes, err := yaml.Marshal(manifest)
+	assert.NilError(t, err, "expected manifest marshal to not fail")
+	assert.NilError(t, os.WriteFile(filepath.Join(tmpDir, "stencil.yaml"), manifestBytes, 0o755),
+		"expected write to stencil.yaml to not fail")
+
+	assert.NilError(t, testRunCommand(t, cmd, tmpDir, "--skip-post-run"), "expected stencil run to not fail")
+
+	goModContent, err := os.ReadFile(filepath.Join(tmpDir, "go.mod"))
+	assert.NilError(t, err, "expected read of go.mod to not fail")
+	assert.Equal(t, string(goModContent), "hello, world!", "expected go.mod to remain unchanged")
+}
+
+// TestStencilGeneratedIgnoreDelete tests that if we delete a
+// .stencilignore in templates that it gets deleted and ignored in the
+// same run of stencil.
+func TestStencilGeneratedIgnoreDelete(t *testing.T) {
+	cmd := NewStencil(slogext.NewTestLogger(t))
+	assert.Assert(t, cmd != nil, "expected NewStencil() to not return nil")
+
+	cwd, err := os.Getwd()
+	assert.NilError(t, err, "expected getting cwd to not fail")
+
+	tmpDir := t.TempDir()
+
+	assert.NilError(t, os.WriteFile(filepath.Join(tmpDir, stencil.StencilIgnoreName), []byte("go.mod"), 0o644),
+		"expected write to %s to not fail", stencil.StencilIgnoreName)
+
+	assert.NilError(t, os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte("hello, world!"), 0o644),
+		"expected write to go.mod to not fail")
+
+	manifest := &configuration.Manifest{
+		Name:         "test-123",
+		Arguments:    map[string]any{"delete": true},
+		Modules:      []*configuration.TemplateRepository{{Name: "module_ignore"}},
+		Replacements: map[string]string{"module_ignore": filepath.Join(cwd, "testdata", "module_ignore")},
+	}
+	manifestBytes, err := yaml.Marshal(manifest)
+	assert.NilError(t, err, "expected manifest marshal to not fail")
+	assert.NilError(t, os.WriteFile(filepath.Join(tmpDir, "stencil.yaml"), manifestBytes, 0o755),
+		"expected write to stencil.yaml to not fail")
+
+	assert.NilError(t, testRunCommand(t, cmd, tmpDir, "--skip-post-run"), "expected stencil run to not fail")
+
+	goModContent, err := os.ReadFile(filepath.Join(tmpDir, "go.mod"))
+	assert.NilError(t, err, "expected read of go.mod to not fail")
+	assert.Equal(t, string(goModContent), "module something\n", "expected go.mod to remain unchanged")
+}

--- a/cmd/stencil/stencil_test.go
+++ b/cmd/stencil/stencil_test.go
@@ -8,6 +8,7 @@ import (
 	"go.rgst.io/jaredallard/slogext/v2"
 	"go.rgst.io/stencil/v2/internal/yaml"
 	"go.rgst.io/stencil/v2/pkg/configuration"
+	"go.rgst.io/stencil/v2/pkg/stencil"
 	"gotest.tools/v3/assert"
 )
 
@@ -25,8 +26,8 @@ func TestStencilKeepsIgnoredFiles(t *testing.T) {
 
 	tmpDir := t.TempDir()
 
-	assert.NilError(t, os.WriteFile(filepath.Join(tmpDir, ".stencilignore"), []byte("go.mod"), 0o644),
-		"expected write to .stencilignore to not fail")
+	assert.NilError(t, os.WriteFile(filepath.Join(tmpDir, stencil.StencilIgnoreName), []byte("go.mod"), 0o644),
+		"expected write to %s to not fail", stencil.StencilIgnoreName)
 
 	assert.NilError(t, os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte("hello, world!"), 0o644),
 		"expected write to go.mod to not fail")

--- a/cmd/stencil/testdata/module_ignore/manifest.yaml
+++ b/cmd/stencil/testdata/module_ignore/manifest.yaml
@@ -1,0 +1,8 @@
+name: module_ignore
+arguments:
+  skip:
+    type: boolean
+    default: false
+  delete:
+    type: boolean
+    default: false

--- a/cmd/stencil/testdata/module_ignore/templates/.stencilignore.tpl
+++ b/cmd/stencil/testdata/module_ignore/templates/.stencilignore.tpl
@@ -1,0 +1,6 @@
+{{- if stencil.Arg "skip" -}}
+{{- file.Skip -}}
+{{- else if stencil.Arg "delete" -}}
+{{- file.Delete -}}
+{{- end }}
+go.mod

--- a/cmd/stencil/testdata/module_ignore/templates/.stencilignore.tpl
+++ b/cmd/stencil/testdata/module_ignore/templates/.stencilignore.tpl
@@ -1,5 +1,5 @@
 {{- if stencil.Arg "skip" -}}
-{{- file.Skip -}}
+{{- file.Skip "argument 'skip' was set to true" -}}
 {{- else if stencil.Arg "delete" -}}
 {{- file.Delete -}}
 {{- end }}

--- a/cmd/stencil/testdata/module_ignore/templates/go.mod.tpl
+++ b/cmd/stencil/testdata/module_ignore/templates/go.mod.tpl
@@ -1,0 +1,1 @@
+module something

--- a/cmd/stencil/upgrade_test.go
+++ b/cmd/stencil/upgrade_test.go
@@ -114,10 +114,6 @@ func TestCanUpgradeModules(t *testing.T) {
 // TestUpgradeIncludesNewModules tests that the upgrade command can install
 // new modules in a project.
 func TestUpgradeIncludesNewModules(t *testing.T) {
-	if os.Getenv("CI") == "true" {
-		t.Skip("Mise+Go are breaking in CI")
-	}
-
 	tmpDir := t.TempDir()
 
 	cmd := NewUpgradeCommand(slogext.NewTestLogger(t))
@@ -126,7 +122,7 @@ func TestUpgradeIncludesNewModules(t *testing.T) {
 	writeML(t, &configuration.Manifest{
 		Name: "testing",
 		Modules: []*configuration.TemplateRepository{{
-			Name: "github.com/rgst-io/stencil-golang",
+			Name: "go.rgst.io/rgst-io/stencil-golang",
 		}},
 		Arguments: map[string]any{
 			"org": "rgst-io",
@@ -148,10 +144,6 @@ func TestUpgradeIncludesNewModules(t *testing.T) {
 // TestUpgradeReRunsStencil tests an upgrade command re-runs stencil
 // even when there is no new version.
 func TestUpgradeReRunsStencil(t *testing.T) {
-	if os.Getenv("CI") == "true" {
-		t.Skip("Mise+Go are breaking in CI")
-	}
-
 	tmpDir := t.TempDir()
 
 	cmd := NewUpgradeCommand(slogext.NewTestLogger(t))
@@ -160,8 +152,8 @@ func TestUpgradeReRunsStencil(t *testing.T) {
 	writeML(t, &configuration.Manifest{
 		Name: "testing",
 		Modules: []*configuration.TemplateRepository{{
-			Name:    "github.com/rgst-io/stencil-golang",
-			Version: "=2.0.1",
+			Name:    "go.rgst.io/rgst-io/stencil-golang",
+			Version: "=4.0.2",
 		}},
 		Arguments: map[string]any{
 			"org": "rgst-io",

--- a/docs/funcs/module.Export.md
+++ b/docs/funcs/module.Export.md
@@ -9,9 +9,7 @@ order: 1016
 Export registers a function to allow it to be called by other templates.
 
 This is only able to be called in library templates and the function's
-name must start with a capital letter. Function names are also only
-eligible to be exported once, if a function is exported twice the second
-call will be a runtime error.
+name must start with a capital letter.
 
 The second argument to "module.Export" controls what "stencil", "file"
 and other template-scoped functions target. Valid options are "caller"

--- a/internal/cmd/stencil/stencil.go
+++ b/internal/cmd/stencil/stencil.go
@@ -390,10 +390,17 @@ func (c *Command) runWithModules(ctx context.Context, mods []*modules.Module) er
 			continue
 		}
 
-		var err error
-		c.ignore, err = stencil.LoadIgnoreFromReader(bytes.NewReader(ignore.Bytes()))
-		if err != nil {
-			return fmt.Errorf("failed to read generated %s: %w", stencil.StencilIgnoreName, err)
+		switch {
+		case ignore.Skipped:
+			// Do nothing when skipped (allows removing ownership)
+		case ignore.Deleted:
+			c.ignore = nil
+		default:
+			var err error
+			c.ignore, err = stencil.LoadIgnoreFromReader(bytes.NewReader(ignore.Bytes()))
+			if err != nil {
+				return fmt.Errorf("failed to read generated %s: %w", stencil.StencilIgnoreName, err)
+			}
 		}
 	}
 

--- a/internal/cmd/stencil/stencil.go
+++ b/internal/cmd/stencil/stencil.go
@@ -22,6 +22,7 @@
 package stencil
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -351,7 +352,7 @@ func (c *Command) Run(ctx context.Context) error {
 	}
 
 	if c.failIgnored && c.ignored {
-		return fmt.Errorf("files were ignored via .stencilignore")
+		return fmt.Errorf("files were ignored via %s", stencil.StencilIgnoreName)
 	}
 
 	return nil
@@ -371,6 +372,29 @@ func (c *Command) runWithModules(ctx context.Context, mods []*modules.Module) er
 	tpls, err := st.Render(ctx, c.log)
 	if err != nil {
 		return err
+	}
+
+	// Check if .stencilignore was generated, if so, re-read it.
+	for _, t := range tpls {
+		var ignore *codegen.File
+		for _, f := range t.Files {
+			if f.Name() != stencil.StencilIgnoreName {
+				continue
+			}
+
+			ignore = f
+			break
+		}
+		if ignore == nil {
+			// No .stencilignore, process the next
+			continue
+		}
+
+		var err error
+		c.ignore, err = stencil.LoadIgnoreFromReader(bytes.NewReader(ignore.Bytes()))
+		if err != nil {
+			return fmt.Errorf("failed to read generated %s: %w", stencil.StencilIgnoreName, err)
+		}
 	}
 
 	if err := c.writeFiles(st, tpls); err != nil {
@@ -403,7 +427,9 @@ func (c *Command) writeFiles(st *codegen.Stencil, tpls []*codegen.Template) erro
 						logFn = c.log.Error
 					}
 
-					logFn(fmt.Sprintf("  -> Skipped %s", fileName), "reason", "matched .stencilignore")
+					logFn(fmt.Sprintf("  -> Skipped %s", fileName),
+						"reason", fmt.Sprintf("matched %s", stencil.StencilIgnoreName),
+					)
 					if c.failIgnored {
 						c.ignored = true
 					}

--- a/internal/codegen/stencil.go
+++ b/internal/codegen/stencil.go
@@ -169,7 +169,7 @@ func (s *Stencil) GenerateLockfile(tpls []*Template) *stencil.Lockfile {
 // provided to stencil at creation time, returned is the templates
 // that were produced and their associated files.
 func (s *Stencil) Render(ctx context.Context, log slogext.Logger) ([]*Template, error) {
-	tplfiles, err := s.getTemplates(ctx, log)
+	tpls, err := s.getTemplates(ctx, log)
 	if err != nil {
 		return nil, err
 	}
@@ -184,14 +184,14 @@ func (s *Stencil) Render(ctx context.Context, log slogext.Logger) ([]*Template, 
 
 	// Add the templates to their modules template to allow them to be able to access
 	// functions declared in the same module
-	for _, t := range tplfiles {
+	for _, t := range tpls {
 		log.Debugf("Parsing template %s", t.ImportPath())
 		if err := t.Parse(s); err != nil {
 			return nil, errors.Wrapf(err, "failed to parse template %q", t.ImportPath())
 		}
 	}
 
-	// Render until we limit or state is stable
+	// Render until we hit the limit or state is stable
 	var lastHash uint64
 	var i int
 	for {
@@ -200,14 +200,14 @@ func (s *Stencil) Render(ctx context.Context, log slogext.Logger) ([]*Template, 
 		}
 
 		log.Debug("Render stage", "iteration", i)
-		for _, t := range tplfiles {
+		for _, t := range tpls {
 			log.Debugf("Render template %s", t.ImportPath())
 			if err := t.Render(s, vals); err != nil {
 				return nil, errors.Wrapf(err, "failed to render template %q", t.ImportPath())
 			}
 
-			// Don't keep files, we only need the shared state modifications.
-			t.Files = nil
+			// We don't need the files.
+			t.Reset()
 		}
 
 		// Calculate the hash of the shared state
@@ -231,15 +231,11 @@ func (s *Stencil) Render(ctx context.Context, log slogext.Logger) ([]*Template, 
 		return nil, err
 	}
 
-	tpls := make([]*Template, 0)
-	for _, t := range tplfiles {
+	for _, t := range tpls {
 		log.Debugf("Final render of template %s", t.ImportPath())
 		if err := t.Render(s, vals); err != nil {
 			return nil, errors.Wrapf(err, "failed to render template %q", t.ImportPath())
 		}
-
-		// append the rendered template to our list of templates processed
-		tpls = append(tpls, t)
 	}
 
 	return tpls, nil

--- a/internal/codegen/template.go
+++ b/internal/codegen/template.go
@@ -68,7 +68,7 @@ type Template struct {
 	// not.
 	extraFiles []*File
 
-	// Module is the underlying module that's creating this template
+	// Module is the underlying module that owns this template
 	Module *modules.Module
 
 	// Path is the path of this template relative to the owning module
@@ -218,4 +218,16 @@ func (t *Template) Render(st *Stencil, vals *Values) error {
 	t.Files = append(t.Files, t.extraFiles...)
 
 	return nil
+}
+
+// Reset resets the state of this template to match what it was when it
+// was created. Note: If the underlying template was parsed (see
+// [Template.parsed]) it will still have been registered on the owning
+// module due to template module state.
+//
+// This is mostly useful for resetting the execution outputs of a
+// template.
+func (t *Template) Reset() {
+	t.Files = nil
+	t.extraFiles = nil
 }

--- a/internal/codegen/tpl_module.go
+++ b/internal/codegen/tpl_module.go
@@ -41,10 +41,6 @@ type TplModule struct {
 	log slogext.Logger
 }
 
-// exportChecks is a map of already exported functions to prevent
-// duplicate exports.
-var exportChecks = make(map[string]struct{})
-
 // executorScope is used by [TplModule.Export] to determine if the
 // function should receive the calling template's scope or use the
 // function's template's scope. See [TplModule.Export] for more
@@ -63,9 +59,7 @@ var (
 // templates.
 //
 // This is only able to be called in library templates and the
-// function's name must start with a capital letter. Function names are
-// also only eligible to be exported once, if a function is exported
-// twice the second call will be a runtime error.
+// function's name must start with a capital letter.
 //
 // The second argument to "module.Export" controls what "stencil",
 // "file" and other template-scoped functions target. Valid options are
@@ -92,13 +86,6 @@ var (
 func (tm *TplModule) Export(name string, scopeSli ...executorScope) (string, error) {
 	// We only allow functions to be exported before the final pass.
 	if tm.s.renderStage == renderStageFinal {
-		// In the final pass, though, check to make sure there's not dupes
-		checkName := fmt.Sprintf("%s.%s", tm.t.Module.Name, name)
-		if _, ok := exportChecks[checkName]; ok {
-			return "", fmt.Errorf("function %q in module %q was already exported", name, tm.t.Module.Name)
-		}
-		exportChecks[checkName] = struct{}{}
-
 		return "", nil
 	}
 

--- a/internal/codegen/tpl_module_test.go
+++ b/internal/codegen/tpl_module_test.go
@@ -76,17 +76,6 @@ func TestTplModule_Tpl(t *testing.T) {
 			want:            "hello",
 		},
 		{
-			name:        "should break on duplicate export",
-			renderStage: renderStageFinal,
-			functionTemplate: `{{- define "HelloWorld" -}}
-		{{ return (fromYaml "hello: world") }}
-		{{- end -}}
-		{{- module.Export "HelloWorld" -}}
-		{{- module.Export "HelloWorld" -}}`,
-			callingTemplate:     ``,
-			wantFuncErrContains: "already exported",
-		},
-		{
 			name: "use context from function",
 			functionTemplate: `{{- stencil.SetGlobal "a" "func" -}}
 		{{- define "HelloWorld" -}}

--- a/pkg/stencil/ignore.go
+++ b/pkg/stencil/ignore.go
@@ -60,7 +60,7 @@ func LoadIgnore(path string) (*Ignore, error) {
 	//nolint:gosec // Why: By design.
 	f, err := os.Open(path)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to open %q: %w", path, err)
 	}
 	defer f.Close()
 

--- a/pkg/stencil/ignore.go
+++ b/pkg/stencil/ignore.go
@@ -64,5 +64,9 @@ func LoadIgnore(path string) (*Ignore, error) {
 	}
 	defer f.Close()
 
-	return LoadIgnoreFromReader(f)
+	ignore, err := LoadIgnoreFromReader(f)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load %q: %w", path, err)
+	}
+	return ignore, nil
 }

--- a/pkg/stencil/ignore.go
+++ b/pkg/stencil/ignore.go
@@ -18,6 +18,8 @@ package stencil
 
 import (
 	"fmt"
+	"io"
+	"os"
 
 	"github.com/codeglyph/go-dotignore/v2"
 )
@@ -38,6 +40,16 @@ type Ignore struct {
 	*dotignore.PatternMatcher
 }
 
+// LoadIgnoreFromReader parses a stencilignore from the given reader.
+func LoadIgnoreFromReader(r io.Reader) (*Ignore, error) {
+	pm, err := dotignore.NewPatternMatcherFromReader(r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse stencilignore: %w", err)
+	}
+
+	return &Ignore{pm}, nil
+}
+
 // LoadIgnore creates a new [Ignore] from the provided path. If path is
 // empty, [StencilIgnoreName] is used.
 func LoadIgnore(path string) (*Ignore, error) {
@@ -45,10 +57,12 @@ func LoadIgnore(path string) (*Ignore, error) {
 		path = StencilIgnoreName
 	}
 
-	pm, err := dotignore.NewPatternMatcherFromFile(path)
+	//nolint:gosec // Why: By design.
+	f, err := os.Open(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open stencilignore %q: %w", path, err)
+		return nil, err
 	}
+	defer f.Close()
 
-	return &Ignore{pm}, nil
+	return LoadIgnoreFromReader(f)
 }


### PR DESCRIPTION
If we detect that `.stencilignore` was generated at render time, we
re-read it before writing files post-render. This enables changes to
`.stencilignore`, owned by a template, not requiring stencil to be 
ran >2 times to take effect.

I also removed the export checks feature, I'm not a fan of how I
implemented that and in practice it's been a bit racey with the template
pass system. I'm on a slow quest to remove global state from the
renderer, which removing this helps (somewhat).