### PR TITLE
fix(module_test): don't swallow validators output

### DIFF
--- a/cmd/stencil/module_tst.go
+++ b/cmd/stencil/module_tst.go
@@ -129,6 +129,8 @@ func runTest(ctx context.Context, log slogext.Logger, dir string, t *Test) error
 
 	for _, validator := range mf.Testing.Validators {
 		cmd := cmdexec.CommandContext(ctx, "bash", "-euo", "pipefail", "-c", validator)
+		cmd.SetStderr(tlogbuf)
+		cmd.SetStdout(tlogbuf)
 		if err := cmd.Run(); err != nil {
 			fmt.Print(tlogbuf.String())
 			return fmt.Errorf("validator failed (%s): %w", cmd.String(), err)

--- a/cmd/stencil/module_tst_test.go
+++ b/cmd/stencil/module_tst_test.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"bytes"
 	"testing"
 
 	"go.rgst.io/jaredallard/slogext/v2"
+	"go.rgst.io/stencil/v2/internal/testing/stdouttest"
 	"gotest.tools/v3/assert"
 )
 
@@ -17,4 +19,16 @@ func TestModuleTestSmokeTestFailure(t *testing.T) {
 	cmd := NewModuleTestCommand(slogext.NewTestLogger(t))
 
 	assert.Error(t, testRunCommand(t, cmd, "cmd/stencil/testdata/module_test_failure"), "tests failed", "expected command to fail")
+}
+
+func TestModuleTestFailureShowsOutput(t *testing.T) {
+	// Some output is written directly to stdout, so we need to capture it
+	// here.
+	out := stdouttest.Run(t, func() {
+		cmd := NewModuleTestCommand(slogext.NewTestLogger(t))
+
+		err := testRunCommand(t, cmd, "cmd/stencil/testdata/module_test_failure")
+		assert.Error(t, err, "tests failed", "expected command to fail")
+	})
+	assert.Assert(t, bytes.Contains(out, []byte("failed!")), "expected output to be included")
 }

--- a/cmd/stencil/testdata/module_test_failure/tests/SmokeTest/stencil.yaml
+++ b/cmd/stencil/testdata/module_test_failure/tests/SmokeTest/stencil.yaml
@@ -3,4 +3,4 @@ arguments:
   hello: "world"
 testing:
   validators:
-    - '[[ "$(cat hello.txt)" != "world" ]]'
+    - '[[ "$(cat hello.txt)" != "world" ]] || { echo "failed!" >&2; exit 1 }'

--- a/internal/codegen/functions.go
+++ b/internal/codegen/functions.go
@@ -52,7 +52,7 @@ func dereference(i any) any {
 	infType := reflect.TypeOf(i)
 
 	// If not a pointer, noop
-	if infType.Kind() != reflect.Ptr {
+	if infType.Kind() != reflect.Pointer {
 		return i
 	}
 

--- a/internal/testing/stdouttest/stdouttest.go
+++ b/internal/testing/stdouttest/stdouttest.go
@@ -1,0 +1,103 @@
+// Copyright (C) 2026 stencil contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package stdouttest contains helpers for capturing stdout in tests.
+package stdouttest
+
+import (
+	"os"
+	"sync"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+// stdouterrLock is used to lock modification of both [os.Stdout] and
+// [os.Stderr].
+var stdouterrLock = sync.Mutex{}
+
+// RunOptions are options for [Run].
+type RunOptions struct {
+	// Stdout denotes if stdout should be captured.
+	Stdout bool
+
+	// Stderr denotes if stderr should be captured.
+	Stderr bool
+}
+
+// Run runs the following code with stdout and stderr captured by
+// default, or as configured with [RunOptions].
+//
+// Note: Run does NOT support being ran in parallel tests and will fail
+// the test if detected.
+func Run(t *testing.T, fn func(), opts ...*RunOptions) []byte {
+	t.Helper()
+	if len(opts) > 1 {
+		t.Fatal("Run: RunOptions can only be provided at most once")
+	}
+
+	var opt *RunOptions
+	if len(opts) == 0 {
+		opt = &RunOptions{
+			Stdout: true,
+			Stderr: true,
+		}
+	} else {
+		opt = opts[0]
+	}
+
+	if !stdouterrLock.TryLock() {
+		t.Fatal("failed to obtain stdout/err lock for capturing. " +
+			"Parallel tests are not supported.")
+	}
+	defer stdouterrLock.Unlock()
+
+	tmpDir := t.TempDir()
+	tmpFile, err := os.CreateTemp(tmpDir, "stdouttest-*")
+	assert.NilError(t, err,
+		"failed to create temp file for stdout/err capturing",
+	)
+
+	if opt.Stdout {
+		origStdout := os.Stdout
+		t.Cleanup(func() {
+			os.Stdout = origStdout
+		})
+
+		os.Stdout = tmpFile
+	}
+
+	if opt.Stderr {
+		origStderr := os.Stderr
+		t.Cleanup(func() {
+			os.Stderr = origStderr
+		})
+
+		os.Stderr = tmpFile
+	}
+
+	fn()
+
+	assert.NilError(t, tmpFile.Close(),
+		"failed to close temp file used for stdout/err capturing",
+	)
+
+	b, err := os.ReadFile(tmpFile.Name())
+	assert.NilError(t, err,
+		"failed to read temp file used for stdout/err capturing",
+	)
+	return b
+}

--- a/internal/testing/stdouttest/stdouttest_test.go
+++ b/internal/testing/stdouttest/stdouttest_test.go
@@ -1,0 +1,34 @@
+package stdouttest_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"go.rgst.io/stencil/v2/internal/testing/stdouttest"
+	"gotest.tools/v3/assert"
+)
+
+func TestDefaultCapturesStdoutAndStderr(t *testing.T) {
+	out := stdouttest.Run(t, func() {
+		fmt.Print("stdout")
+		fmt.Fprint(os.Stderr, "stderr")
+	})
+	assert.Equal(t, string(out), "stdoutstderr")
+}
+
+func TestDisableStderr(t *testing.T) {
+	out := stdouttest.Run(t, func() {
+		fmt.Print("stdout")
+		fmt.Fprint(os.Stderr, "stderr")
+	}, &stdouttest.RunOptions{Stdout: true})
+	assert.Equal(t, string(out), "stdout")
+}
+
+func TestDisableStdout(t *testing.T) {
+	out := stdouttest.Run(t, func() {
+		fmt.Print("stdout")
+		fmt.Fprint(os.Stderr, "stderr")
+	}, &stdouttest.RunOptions{Stderr: true})
+	assert.Equal(t, string(out), "stderr")
+}


### PR DESCRIPTION
Without this, when a test failed there would be no output from the
validators. Now, we show the output when it fails. This was a miss in
the original implementation.

To be able to test this, I've added a new `stdouttest` package that
captures stdout/err within the run. It is subject to the same parallel
testing limitations that cmdexec is.
